### PR TITLE
feat: TypeScript types and API client layer

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,20 @@
+import type { AuthResponse, LoginRequest } from '@/types';
+import { apiPost, AUTH_TOKEN_KEY } from './client';
+
+export const authApi = {
+  /** Authenticate with username and password. Returns a JWT token. */
+  login: (data: LoginRequest) =>
+    apiPost<AuthResponse>('/auth/login', data),
+
+  /** Store the JWT token in localStorage. */
+  setToken: (token: string) =>
+    localStorage.setItem(AUTH_TOKEN_KEY, token),
+
+  /** Remove the JWT token from localStorage. */
+  clearToken: () =>
+    localStorage.removeItem(AUTH_TOKEN_KEY),
+
+  /** Check if a JWT token exists in localStorage. */
+  isAuthenticated: () =>
+    localStorage.getItem(AUTH_TOKEN_KEY) !== null,
+};

--- a/src/api/blog.ts
+++ b/src/api/blog.ts
@@ -1,0 +1,177 @@
+import type {
+  BlogPostResponse,
+  BlogCategoryResponse,
+  BlogTagResponse,
+  BlogPostImageResponse,
+  PageResponse,
+  PaginationParams,
+  CreateBlogPostRequest,
+  UpdateBlogPostRequest,
+  CreateBlogCategoryRequest,
+  UpdateBlogCategoryRequest,
+  CreateBlogTagRequest,
+  UpdateBlogTagRequest,
+  CreateBlogPostImageRequest,
+  UpdateBlogPostImageRequest,
+} from '@/types';
+import { apiGet, apiPost, apiPut, apiDelete, apiClient } from './client';
+
+export const blogApi = {
+  // ==========================================================================
+  // Posts
+  // ==========================================================================
+  posts: {
+    // Public
+    getAll: () =>
+      apiGet<BlogPostResponse[]>('/blog/posts'),
+
+    getPublished: () =>
+      apiGet<BlogPostResponse[]>('/blog/posts/published'),
+
+    getPublishedPaginated: (params?: PaginationParams) =>
+      apiGet<PageResponse<BlogPostResponse>>('/blog/posts/published/paginated', params as Record<string, unknown>),
+
+    getById: (id: number) =>
+      apiGet<BlogPostResponse>(`/blog/posts/${id}`),
+
+    /** Fetching by slug increments the view count on the backend. */
+    getBySlug: (slug: string) =>
+      apiGet<BlogPostResponse>(`/blog/posts/slug/${slug}`),
+
+    getByCategory: (categorySlug: string) =>
+      apiGet<BlogPostResponse[]>(`/blog/posts/category/${categorySlug}`),
+
+    getByTag: (tagSlug: string) =>
+      apiGet<BlogPostResponse[]>(`/blog/posts/tag/${tagSlug}`),
+
+    search: (query: string) =>
+      apiGet<BlogPostResponse[]>('/blog/posts/search', { q: query }),
+
+    // Admin
+    /** @admin */
+    create: (data: CreateBlogPostRequest) =>
+      apiPost<BlogPostResponse>('/blog/posts', data),
+
+    /** @admin */
+    update: (id: number, data: UpdateBlogPostRequest) =>
+      apiPut<BlogPostResponse>(`/blog/posts/${id}`, data),
+
+    /** @admin */
+    remove: (id: number) =>
+      apiDelete(`/blog/posts/${id}`),
+
+    /** @admin */
+    publish: (id: number) =>
+      apiPut<BlogPostResponse>(`/blog/posts/${id}/publish`),
+
+    /** @admin */
+    unpublish: (id: number) =>
+      apiPut<BlogPostResponse>(`/blog/posts/${id}/unpublish`),
+
+    /** @admin */
+    addCategory: (postId: number, categoryId: number) =>
+      apiPost<void>(`/blog/posts/${postId}/categories/${categoryId}`),
+
+    /** @admin */
+    removeCategory: (postId: number, categoryId: number) =>
+      apiDelete(`/blog/posts/${postId}/categories/${categoryId}`),
+
+    /** @admin */
+    addTag: (postId: number, tagId: number) =>
+      apiPost<void>(`/blog/posts/${postId}/tags/${tagId}`),
+
+    /** @admin */
+    removeTag: (postId: number, tagId: number) =>
+      apiDelete(`/blog/posts/${postId}/tags/${tagId}`),
+  },
+
+  // ==========================================================================
+  // Categories
+  // ==========================================================================
+  categories: {
+    getAll: () =>
+      apiGet<BlogCategoryResponse[]>('/blog/categories'),
+
+    getById: (id: number) =>
+      apiGet<BlogCategoryResponse>(`/blog/categories/${id}`),
+
+    getBySlug: (slug: string) =>
+      apiGet<BlogCategoryResponse>(`/blog/categories/slug/${slug}`),
+
+    /** @admin */
+    create: (data: CreateBlogCategoryRequest) =>
+      apiPost<BlogCategoryResponse>('/blog/categories', data),
+
+    /** @admin */
+    update: (id: number, data: UpdateBlogCategoryRequest) =>
+      apiPut<BlogCategoryResponse>(`/blog/categories/${id}`, data),
+
+    /** @admin */
+    remove: (id: number) =>
+      apiDelete(`/blog/categories/${id}`),
+  },
+
+  // ==========================================================================
+  // Tags
+  // ==========================================================================
+  tags: {
+    getAll: () =>
+      apiGet<BlogTagResponse[]>('/blog/tags'),
+
+    getPopular: () =>
+      apiGet<BlogTagResponse[]>('/blog/tags/popular'),
+
+    getById: (id: number) =>
+      apiGet<BlogTagResponse>(`/blog/tags/${id}`),
+
+    getBySlug: (slug: string) =>
+      apiGet<BlogTagResponse>(`/blog/tags/slug/${slug}`),
+
+    /** @admin */
+    create: (data: CreateBlogTagRequest) =>
+      apiPost<BlogTagResponse>('/blog/tags', data),
+
+    /** @admin */
+    update: (id: number, data: UpdateBlogTagRequest) =>
+      apiPut<BlogTagResponse>(`/blog/tags/${id}`, data),
+
+    /** @admin */
+    remove: (id: number) =>
+      apiDelete(`/blog/tags/${id}`),
+  },
+
+  // ==========================================================================
+  // Post Images
+  // ==========================================================================
+  images: {
+    getAll: (postId: number) =>
+      apiGet<BlogPostImageResponse[]>(`/blog/posts/${postId}/images`),
+
+    getById: (postId: number, imageId: number) =>
+      apiGet<BlogPostImageResponse>(`/blog/posts/${postId}/images/${imageId}`),
+
+    /** @admin — Upload a blog post image (multipart/form-data). */
+    create: (postId: number, file: File, metadata: CreateBlogPostImageRequest) => {
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('metadata', JSON.stringify(metadata));
+      return apiClient.post<BlogPostImageResponse>(
+        `/blog/posts/${postId}/images`,
+        formData,
+        { headers: { 'Content-Type': 'multipart/form-data' } },
+      ).then(r => r.data);
+    },
+
+    /** @admin */
+    update: (postId: number, imageId: number, data: UpdateBlogPostImageRequest) =>
+      apiPut<BlogPostImageResponse>(`/blog/posts/${postId}/images/${imageId}`, data),
+
+    /** @admin */
+    setPrimary: (postId: number, imageId: number) =>
+      apiPut<BlogPostImageResponse>(`/blog/posts/${postId}/images/${imageId}/primary`),
+
+    /** @admin */
+    remove: (postId: number, imageId: number) =>
+      apiDelete(`/blog/posts/${postId}/images/${imageId}`),
+  },
+};

--- a/src/api/certifications.ts
+++ b/src/api/certifications.ts
@@ -1,0 +1,57 @@
+import type {
+  CertificationResponse,
+  CreateCertificationRequest,
+  UpdateCertificationRequest,
+} from '@/types';
+import { apiGet, apiPost, apiPut, apiDelete } from './client';
+
+export const certificationApi = {
+  // --------------------------------------------------------------------------
+  // Public
+  // --------------------------------------------------------------------------
+
+  getAll: () =>
+    apiGet<CertificationResponse[]>('/certifications'),
+
+  getById: (id: number) =>
+    apiGet<CertificationResponse>(`/certifications/${id}`),
+
+  getBySlug: (slug: string) =>
+    apiGet<CertificationResponse>(`/certifications/slug/${slug}`),
+
+  getByStatus: (status: string) =>
+    apiGet<CertificationResponse[]>(`/certifications/status/${status}`),
+
+  getPublished: () =>
+    apiGet<CertificationResponse[]>('/certifications/published'),
+
+  getFeatured: () =>
+    apiGet<CertificationResponse[]>('/certifications/featured'),
+
+  getByOrganization: (org: string) =>
+    apiGet<CertificationResponse[]>(`/certifications/organization/${org}`),
+
+  // --------------------------------------------------------------------------
+  // Admin
+  // --------------------------------------------------------------------------
+
+  /** @admin */
+  create: (data: CreateCertificationRequest) =>
+    apiPost<CertificationResponse>('/certifications', data),
+
+  /** @admin */
+  update: (id: number, data: UpdateCertificationRequest) =>
+    apiPut<CertificationResponse>(`/certifications/${id}`, data),
+
+  /** @admin */
+  remove: (id: number) =>
+    apiDelete(`/certifications/${id}`),
+
+  /** @admin — Link a technology to a certification. */
+  addTechnology: (certId: number, techId: number) =>
+    apiPost<void>(`/certifications/${certId}/technologies/${techId}`),
+
+  /** @admin — Unlink a technology from a certification. */
+  removeTechnology: (certId: number, techId: number) =>
+    apiDelete(`/certifications/${certId}/technologies/${techId}`),
+};

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,29 @@
 import axios from 'axios';
 import { env } from '@/config';
+import type { ApiResponse, ValidationError } from '@/types';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+export const AUTH_TOKEN_KEY = 'auth_token';
+
+// ============================================================================
+// Error type
+// ============================================================================
+
+/** Structured error thrown by the API client on failed requests. */
+export interface ApiError {
+  status: number;
+  message: string;
+  errorCode?: string;
+  validationErrors?: ValidationError[];
+  requestId?: string;
+}
+
+// ============================================================================
+// Axios instance
+// ============================================================================
 
 export const apiClient = axios.create({
   baseURL: env.apiBaseUrl,
@@ -7,3 +31,88 @@ export const apiClient = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+// ============================================================================
+// Request interceptor — inject JWT token
+// ============================================================================
+
+apiClient.interceptors.request.use((config) => {
+  const token = localStorage.getItem(AUTH_TOKEN_KEY);
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// ============================================================================
+// Response interceptor — unwrap ApiResponse envelope + handle errors
+// ============================================================================
+
+apiClient.interceptors.response.use(
+  // Success: unwrap the ApiResponse<T> envelope → return just the data
+  (response) => {
+    const body = response.data as ApiResponse<unknown>;
+    response.data = body.data;
+    return response;
+  },
+
+  // Error: parse the error response into a structured ApiError
+  (error) => {
+    if (axios.isAxiosError(error) && error.response) {
+      const { status, data } = error.response;
+
+      // Clear token on 401 (expired or invalid)
+      if (status === 401) {
+        localStorage.removeItem(AUTH_TOKEN_KEY);
+      }
+
+      // Parse the backend error envelope
+      const body = data as Partial<ApiResponse<unknown>> | undefined;
+      const apiError: ApiError = {
+        status,
+        message: body?.message ?? error.message,
+        errorCode: body?.errorCode,
+        requestId: body?.requestId,
+        validationErrors: (body?.data as ValidationError[] | undefined),
+      };
+      return Promise.reject(apiError);
+    }
+
+    // Network error or unexpected failure
+    const apiError: ApiError = {
+      status: 0,
+      message: error instanceof Error ? error.message : 'An unexpected error occurred',
+    };
+    return Promise.reject(apiError);
+  },
+);
+
+// ============================================================================
+// Typed helper functions
+// ============================================================================
+
+/**
+ * These helpers exist because the response interceptor unwraps the ApiResponse
+ * envelope, but Axios's generic type parameter doesn't know about that. These
+ * functions bridge the gap so service methods return Promise<T> correctly.
+ */
+
+export async function apiGet<T>(url: string, params?: Record<string, unknown>): Promise<T> {
+  const response = await apiClient.get<T>(url, { params });
+  return response.data;
+}
+
+export async function apiPost<T>(url: string, data?: unknown): Promise<T> {
+  const response = await apiClient.post<T>(url, data);
+  return response.data;
+}
+
+export async function apiPut<T>(url: string, data?: unknown): Promise<T> {
+  const response = await apiClient.put<T>(url, data);
+  return response.data;
+}
+
+export async function apiDelete<T = void>(url: string): Promise<T> {
+  const response = await apiClient.delete<T>(url);
+  return response.data;
+}

--- a/src/api/contact.ts
+++ b/src/api/contact.ts
@@ -1,0 +1,44 @@
+import type {
+  ContactSubmissionResponse,
+  ContactSubmissionRequest,
+  UpdateContactStatusRequest,
+} from '@/types';
+import { apiGet, apiPost, apiPut, apiDelete } from './client';
+
+export const contactApi = {
+  // --------------------------------------------------------------------------
+  // Public
+  // --------------------------------------------------------------------------
+
+  /** Submit a contact form (public, rate-limited). */
+  submit: (data: ContactSubmissionRequest) =>
+    apiPost<ContactSubmissionResponse>('/contact', data),
+
+  // --------------------------------------------------------------------------
+  // Admin
+  // --------------------------------------------------------------------------
+
+  /** @admin */
+  getAll: () =>
+    apiGet<ContactSubmissionResponse[]>('/contact'),
+
+  /** @admin */
+  getById: (id: number) =>
+    apiGet<ContactSubmissionResponse>(`/contact/${id}`),
+
+  /** @admin */
+  getByStatus: (status: string) =>
+    apiGet<ContactSubmissionResponse[]>(`/contact/status/${status}`),
+
+  /** @admin */
+  getByInquiryType: (type: string) =>
+    apiGet<ContactSubmissionResponse[]>(`/contact/inquiry-type/${type}`),
+
+  /** @admin */
+  updateStatus: (id: number, data: UpdateContactStatusRequest) =>
+    apiPut<ContactSubmissionResponse>(`/contact/${id}/status`, data),
+
+  /** @admin */
+  remove: (id: number) =>
+    apiDelete(`/contact/${id}`),
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,1 +1,9 @@
 export { apiClient } from './client';
+export type { ApiError } from './client';
+export { authApi } from './auth';
+export { projectApi } from './projects';
+export { technologyApi } from './technologies';
+export { certificationApi } from './certifications';
+export { blogApi } from './blog';
+export { contactApi } from './contact';
+export { resumeApi } from './resume';

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -1,0 +1,121 @@
+import type {
+  ProjectResponse,
+  ProjectImageResponse,
+  ProjectLinkResponse,
+  PageResponse,
+  PaginationParams,
+  CreateProjectRequest,
+  UpdateProjectRequest,
+  CreateProjectImageRequest,
+  UpdateProjectImageRequest,
+  CreateProjectLinkRequest,
+  UpdateProjectLinkRequest,
+} from '@/types';
+import { apiGet, apiPost, apiPut, apiDelete, apiClient } from './client';
+
+export const projectApi = {
+  // --------------------------------------------------------------------------
+  // Projects — Public
+  // --------------------------------------------------------------------------
+
+  getAll: () =>
+    apiGet<ProjectResponse[]>('/projects'),
+
+  getPaginated: (params?: PaginationParams) =>
+    apiGet<PageResponse<ProjectResponse>>('/projects/paginated', params as Record<string, unknown>),
+
+  getById: (id: number) =>
+    apiGet<ProjectResponse>(`/projects/${id}`),
+
+  getBySlug: (slug: string) =>
+    apiGet<ProjectResponse>(`/projects/slug/${slug}`),
+
+  getByTechnology: (tech: string) =>
+    apiGet<ProjectResponse[]>(`/projects/technology/${tech}`),
+
+  getPublished: () =>
+    apiGet<ProjectResponse[]>('/projects/published'),
+
+  getFeatured: () =>
+    apiGet<ProjectResponse[]>('/projects/featured'),
+
+  // --------------------------------------------------------------------------
+  // Projects — Admin
+  // --------------------------------------------------------------------------
+
+  /** @admin */
+  create: (data: CreateProjectRequest) =>
+    apiPost<ProjectResponse>('/projects', data),
+
+  /** @admin */
+  update: (id: number, data: UpdateProjectRequest) =>
+    apiPut<ProjectResponse>(`/projects/${id}`, data),
+
+  /** @admin */
+  remove: (id: number) =>
+    apiDelete(`/projects/${id}`),
+
+  // --------------------------------------------------------------------------
+  // Project Images — Public
+  // --------------------------------------------------------------------------
+
+  getImages: (projectId: number) =>
+    apiGet<ProjectImageResponse[]>(`/projects/${projectId}/images`),
+
+  getImage: (projectId: number, imageId: number) =>
+    apiGet<ProjectImageResponse>(`/projects/${projectId}/images/${imageId}`),
+
+  // --------------------------------------------------------------------------
+  // Project Images — Admin
+  // --------------------------------------------------------------------------
+
+  /** @admin — Upload a project image (multipart/form-data). */
+  createImage: (projectId: number, file: File, metadata: CreateProjectImageRequest) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('metadata', JSON.stringify(metadata));
+    return apiClient.post<ProjectImageResponse>(
+      `/projects/${projectId}/images`,
+      formData,
+      { headers: { 'Content-Type': 'multipart/form-data' } },
+    ).then(r => r.data);
+  },
+
+  /** @admin */
+  updateImage: (projectId: number, imageId: number, data: UpdateProjectImageRequest) =>
+    apiPut<ProjectImageResponse>(`/projects/${projectId}/images/${imageId}`, data),
+
+  /** @admin */
+  setPrimaryImage: (projectId: number, imageId: number) =>
+    apiPut<ProjectImageResponse>(`/projects/${projectId}/images/${imageId}/set-primary`),
+
+  /** @admin */
+  deleteImage: (projectId: number, imageId: number) =>
+    apiDelete(`/projects/${projectId}/images/${imageId}`),
+
+  // --------------------------------------------------------------------------
+  // Project Links — Public
+  // --------------------------------------------------------------------------
+
+  getLinks: (projectId: number) =>
+    apiGet<ProjectLinkResponse[]>(`/projects/${projectId}/links`),
+
+  getLink: (projectId: number, linkId: number) =>
+    apiGet<ProjectLinkResponse>(`/projects/${projectId}/links/${linkId}`),
+
+  // --------------------------------------------------------------------------
+  // Project Links — Admin
+  // --------------------------------------------------------------------------
+
+  /** @admin */
+  createLink: (projectId: number, data: CreateProjectLinkRequest) =>
+    apiPost<ProjectLinkResponse>(`/projects/${projectId}/links`, data),
+
+  /** @admin */
+  updateLink: (projectId: number, linkId: number, data: UpdateProjectLinkRequest) =>
+    apiPut<ProjectLinkResponse>(`/projects/${projectId}/links/${linkId}`, data),
+
+  /** @admin */
+  deleteLink: (projectId: number, linkId: number) =>
+    apiDelete(`/projects/${projectId}/links/${linkId}`),
+};

--- a/src/api/resume.ts
+++ b/src/api/resume.ts
@@ -1,0 +1,41 @@
+import type { ResumeResponse } from '@/types';
+import { env } from '@/config';
+import { apiGet, apiDelete, apiClient } from './client';
+
+export const resumeApi = {
+  // --------------------------------------------------------------------------
+  // Public
+  // --------------------------------------------------------------------------
+
+  /** Get resume metadata (file name, size, upload date). */
+  getMetadata: () =>
+    apiGet<ResumeResponse>('/resume'),
+
+  /**
+   * Get the resume download URL.
+   * The backend returns a 302 redirect to Cloudinary, so we expose the URL
+   * string for use in <a href> or window.open() rather than making an
+   * Axios call that would follow the redirect.
+   */
+  getDownloadUrl: () =>
+    `${env.apiBaseUrl}/resume/download`,
+
+  // --------------------------------------------------------------------------
+  // Admin
+  // --------------------------------------------------------------------------
+
+  /** @admin — Upload a new resume PDF (replaces existing). */
+  upload: (file: File) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    return apiClient.post<ResumeResponse>(
+      '/resume',
+      formData,
+      { headers: { 'Content-Type': 'multipart/form-data' } },
+    ).then(r => r.data);
+  },
+
+  /** @admin */
+  remove: () =>
+    apiDelete('/resume'),
+};

--- a/src/api/technologies.ts
+++ b/src/api/technologies.ts
@@ -1,0 +1,46 @@
+import type {
+  TechnologyResponse,
+  CreateTechnologyRequest,
+  UpdateTechnologyRequest,
+} from '@/types';
+import { apiGet, apiPost, apiPut, apiDelete } from './client';
+
+export const technologyApi = {
+  // --------------------------------------------------------------------------
+  // Public
+  // --------------------------------------------------------------------------
+
+  getAll: () =>
+    apiGet<TechnologyResponse[]>('/technologies'),
+
+  getById: (id: number) =>
+    apiGet<TechnologyResponse>(`/technologies/${id}`),
+
+  getByCategory: (category: string) =>
+    apiGet<TechnologyResponse[]>(`/technologies/category/${category}`),
+
+  getByProficiency: (level: string) =>
+    apiGet<TechnologyResponse[]>(`/technologies/proficiency/${level}`),
+
+  getFeatured: () =>
+    apiGet<TechnologyResponse[]>('/technologies/featured'),
+
+  getMostUsed: () =>
+    apiGet<TechnologyResponse[]>('/technologies/most-used'),
+
+  // --------------------------------------------------------------------------
+  // Admin
+  // --------------------------------------------------------------------------
+
+  /** @admin */
+  create: (data: CreateTechnologyRequest) =>
+    apiPost<TechnologyResponse>('/technologies', data),
+
+  /** @admin */
+  update: (id: number, data: UpdateTechnologyRequest) =>
+    apiPut<TechnologyResponse>(`/technologies/${id}`, data),
+
+  /** @admin */
+  remove: (id: number) =>
+    apiDelete(`/technologies/${id}`),
+};

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,33 @@
+/** Backend API response envelope — all endpoints return this wrapper. */
+export interface ApiResponse<T> {
+  status: string;
+  errorCode?: string;
+  message: string;
+  data: T;
+  timestamp: string;
+  requestId: string;
+}
+
+/** Field-level validation error returned by the backend. */
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+/** Spring Page response for paginated endpoints. */
+export interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+  first: boolean;
+  last: boolean;
+}
+
+/** Query parameters for paginated API calls. */
+export interface PaginationParams {
+  page?: number;
+  size?: number;
+  sort?: string;
+}

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,0 +1,120 @@
+// ============================================================================
+// Project Domain
+// ============================================================================
+
+export const ProjectType = {
+  PERSONAL: 'PERSONAL',
+  PROFESSIONAL: 'PROFESSIONAL',
+  OPEN_SOURCE: 'OPEN_SOURCE',
+  LEARNING: 'LEARNING',
+  FREELANCE: 'FREELANCE',
+} as const;
+export type ProjectType = (typeof ProjectType)[keyof typeof ProjectType];
+
+export const ProjectStatus = {
+  PLANNING: 'PLANNING',
+  IN_PROGRESS: 'IN_PROGRESS',
+  COMPLETED: 'COMPLETED',
+  MAINTAINED: 'MAINTAINED',
+  ARCHIVED: 'ARCHIVED',
+} as const;
+export type ProjectStatus = (typeof ProjectStatus)[keyof typeof ProjectStatus];
+
+export const DifficultyLevel = {
+  BEGINNER: 'BEGINNER',
+  INTERMEDIATE: 'INTERMEDIATE',
+  ADVANCED: 'ADVANCED',
+  EXPERT: 'EXPERT',
+} as const;
+export type DifficultyLevel = (typeof DifficultyLevel)[keyof typeof DifficultyLevel];
+
+export const ImageType = {
+  THUMBNAIL: 'THUMBNAIL',
+  SCREENSHOT: 'SCREENSHOT',
+  ARCHITECTURE_DIAGRAM: 'ARCHITECTURE_DIAGRAM',
+  UI_MOCKUP: 'UI_MOCKUP',
+  LOGO: 'LOGO',
+} as const;
+export type ImageType = (typeof ImageType)[keyof typeof ImageType];
+
+export const LinkType = {
+  GITHUB: 'GITHUB',
+  LIVE: 'LIVE',
+  DEMO: 'DEMO',
+  STAGING: 'STAGING',
+  DOCUMENTATION: 'DOCUMENTATION',
+  DOCKER: 'DOCKER',
+  NPM: 'NPM',
+  MAVEN: 'MAVEN',
+  API: 'API',
+  OTHER: 'OTHER',
+} as const;
+export type LinkType = (typeof LinkType)[keyof typeof LinkType];
+
+// ============================================================================
+// Technology Domain
+// ============================================================================
+
+export const TechnologyCategory = {
+  LANGUAGE: 'LANGUAGE',
+  FRAMEWORK: 'FRAMEWORK',
+  LIBRARY: 'LIBRARY',
+  DATABASE: 'DATABASE',
+  TOOL: 'TOOL',
+  CLOUD: 'CLOUD',
+  DEPLOYMENT: 'DEPLOYMENT',
+  TESTING: 'TESTING',
+} as const;
+export type TechnologyCategory = (typeof TechnologyCategory)[keyof typeof TechnologyCategory];
+
+export const ProficiencyLevel = {
+  LEARNING: 'LEARNING',
+  FAMILIAR: 'FAMILIAR',
+  PROFICIENT: 'PROFICIENT',
+  EXPERT: 'EXPERT',
+} as const;
+export type ProficiencyLevel = (typeof ProficiencyLevel)[keyof typeof ProficiencyLevel];
+
+// ============================================================================
+// Blog Domain
+// ============================================================================
+
+export const BlogImageType = {
+  FEATURED: 'FEATURED',
+  INLINE: 'INLINE',
+  GALLERY: 'GALLERY',
+  THUMBNAIL: 'THUMBNAIL',
+} as const;
+export type BlogImageType = (typeof BlogImageType)[keyof typeof BlogImageType];
+
+// ============================================================================
+// Certification Domain
+// ============================================================================
+
+export const CertificationStatus = {
+  EARNED: 'EARNED',
+  IN_PROGRESS: 'IN_PROGRESS',
+  EXPIRED: 'EXPIRED',
+} as const;
+export type CertificationStatus = (typeof CertificationStatus)[keyof typeof CertificationStatus];
+
+// ============================================================================
+// Contact Domain
+// ============================================================================
+
+export const InquiryType = {
+  GENERAL: 'GENERAL',
+  PROJECT: 'PROJECT',
+  COLLABORATION: 'COLLABORATION',
+  HIRING: 'HIRING',
+  FREELANCE: 'FREELANCE',
+} as const;
+export type InquiryType = (typeof InquiryType)[keyof typeof InquiryType];
+
+export const SubmissionStatus = {
+  NEW: 'NEW',
+  READ: 'READ',
+  REPLIED: 'REPLIED',
+  ARCHIVED: 'ARCHIVED',
+} as const;
+export type SubmissionStatus = (typeof SubmissionStatus)[keyof typeof SubmissionStatus];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,64 @@
+// Enums (exported as values AND types — the const objects are runtime values)
+export {
+  ProjectType,
+  ProjectStatus,
+  DifficultyLevel,
+  ImageType,
+  LinkType,
+  TechnologyCategory,
+  ProficiencyLevel,
+  BlogImageType,
+  CertificationStatus,
+  InquiryType,
+  SubmissionStatus,
+} from './enums';
+
+// Common types
+export type {
+  ApiResponse,
+  ValidationError,
+  PageResponse,
+  PaginationParams,
+} from './common';
+
+// Response DTOs
+export type {
+  AuthResponse,
+  ProjectResponse,
+  ProjectImageResponse,
+  ProjectLinkResponse,
+  TechnologyResponse,
+  CertificationResponse,
+  BlogPostResponse,
+  BlogCategoryResponse,
+  BlogTagResponse,
+  BlogPostImageResponse,
+  ContactSubmissionResponse,
+  ResumeResponse,
+  HealthResponse,
+} from './responses';
+
+// Request DTOs
+export type {
+  LoginRequest,
+  CreateProjectRequest,
+  UpdateProjectRequest,
+  CreateProjectLinkRequest,
+  UpdateProjectLinkRequest,
+  CreateProjectImageRequest,
+  UpdateProjectImageRequest,
+  CreateTechnologyRequest,
+  UpdateTechnologyRequest,
+  CreateCertificationRequest,
+  UpdateCertificationRequest,
+  CreateBlogPostRequest,
+  UpdateBlogPostRequest,
+  CreateBlogCategoryRequest,
+  UpdateBlogCategoryRequest,
+  CreateBlogTagRequest,
+  UpdateBlogTagRequest,
+  CreateBlogPostImageRequest,
+  UpdateBlogPostImageRequest,
+  ContactSubmissionRequest,
+  UpdateContactStatusRequest,
+} from './requests';

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -1,0 +1,231 @@
+import type {
+  ProjectType,
+  ProjectStatus,
+  DifficultyLevel,
+  ImageType,
+  LinkType,
+  TechnologyCategory,
+  ProficiencyLevel,
+  BlogImageType,
+  CertificationStatus,
+  InquiryType,
+  SubmissionStatus,
+} from './enums';
+
+// ============================================================================
+// Auth
+// ============================================================================
+
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+// ============================================================================
+// Projects
+// ============================================================================
+
+export interface CreateProjectRequest {
+  name: string;
+  slug?: string;
+  shortDescription: string;
+  fullDescription?: string;
+  type: ProjectType;
+  status?: ProjectStatus;
+  difficultyLevel?: DifficultyLevel;
+  startDate?: string;
+  completionDate?: string;
+  estimatedHours?: number;
+  published?: boolean;
+  featured?: boolean;
+  displayOrder?: number;
+  technologyIds?: number[];
+  links?: CreateProjectLinkRequest[];
+}
+
+export interface UpdateProjectRequest {
+  name: string;
+  slug?: string;
+  shortDescription: string;
+  fullDescription?: string;
+  type: ProjectType;
+  status?: ProjectStatus;
+  difficultyLevel?: DifficultyLevel;
+  startDate?: string;
+  completionDate?: string;
+  estimatedHours?: number;
+  published?: boolean;
+  featured?: boolean;
+  displayOrder?: number;
+  technologyIds?: number[];
+}
+
+export interface CreateProjectLinkRequest {
+  type: LinkType;
+  url: string;
+  label?: string;
+  displayOrder?: number;
+}
+
+export interface UpdateProjectLinkRequest {
+  type?: LinkType;
+  url?: string;
+  label?: string;
+  displayOrder?: number;
+}
+
+export interface CreateProjectImageRequest {
+  imageType: ImageType;
+  altText?: string;
+  caption?: string;
+  displayOrder?: number;
+  isPrimary?: boolean;
+}
+
+export interface UpdateProjectImageRequest {
+  imageType?: ImageType;
+  altText?: string;
+  caption?: string;
+  displayOrder?: number;
+  isPrimary?: boolean;
+}
+
+// ============================================================================
+// Technologies
+// ============================================================================
+
+export interface CreateTechnologyRequest {
+  name: string;
+  version?: string;
+  category: TechnologyCategory;
+  iconUrl?: string;
+  color?: string;
+  documentationUrl?: string;
+  proficiencyLevel?: ProficiencyLevel;
+  yearsExperience?: number;
+  featured?: boolean;
+}
+
+export interface UpdateTechnologyRequest {
+  name: string;
+  version?: string;
+  category: TechnologyCategory;
+  iconUrl?: string;
+  color?: string;
+  documentationUrl?: string;
+  proficiencyLevel?: ProficiencyLevel;
+  yearsExperience?: number;
+  featured?: boolean;
+}
+
+// ============================================================================
+// Certifications
+// ============================================================================
+
+export interface CreateCertificationRequest {
+  name: string;
+  issuingOrganization: string;
+  credentialId?: string;
+  credentialUrl?: string;
+  issueDate?: string;
+  expirationDate?: string;
+  status: CertificationStatus;
+  description?: string;
+  badgeUrl?: string;
+  published?: boolean;
+  featured?: boolean;
+  displayOrder?: number;
+  technologyIds?: number[];
+}
+
+export interface UpdateCertificationRequest {
+  name?: string;
+  issuingOrganization?: string;
+  credentialId?: string;
+  credentialUrl?: string;
+  issueDate?: string;
+  expirationDate?: string;
+  status?: CertificationStatus;
+  description?: string;
+  badgeUrl?: string;
+  published?: boolean;
+  featured?: boolean;
+  displayOrder?: number;
+  technologyIds?: number[];
+}
+
+// ============================================================================
+// Blog
+// ============================================================================
+
+export interface CreateBlogPostRequest {
+  title: string;
+  slug?: string;
+  content: string;
+  excerpt?: string;
+  published?: boolean;
+  readTimeMinutes?: number;
+  categoryIds?: number[];
+  tagIds?: number[];
+}
+
+export interface UpdateBlogPostRequest {
+  title?: string;
+  content?: string;
+  excerpt?: string;
+  readTimeMinutes?: number;
+  categoryIds?: number[];
+  tagIds?: number[];
+}
+
+export interface CreateBlogCategoryRequest {
+  name: string;
+  description?: string;
+  color?: string;
+}
+
+export interface UpdateBlogCategoryRequest {
+  name?: string;
+  description?: string;
+  color?: string;
+}
+
+export interface CreateBlogTagRequest {
+  name: string;
+}
+
+export interface UpdateBlogTagRequest {
+  name?: string;
+}
+
+export interface CreateBlogPostImageRequest {
+  imageType: BlogImageType;
+  altText?: string;
+  caption?: string;
+  displayOrder?: number;
+  isPrimary?: boolean;
+}
+
+export interface UpdateBlogPostImageRequest {
+  altText?: string;
+  caption?: string;
+  imageType?: BlogImageType;
+  displayOrder?: number;
+  isPrimary?: boolean;
+}
+
+// ============================================================================
+// Contact
+// ============================================================================
+
+export interface ContactSubmissionRequest {
+  name: string;
+  email: string;
+  subject?: string;
+  message: string;
+  inquiryType?: InquiryType;
+}
+
+export interface UpdateContactStatusRequest {
+  status: SubmissionStatus;
+}

--- a/src/types/responses.ts
+++ b/src/types/responses.ts
@@ -1,0 +1,213 @@
+import type {
+  ProjectType,
+  ProjectStatus,
+  DifficultyLevel,
+  ImageType,
+  LinkType,
+  TechnologyCategory,
+  ProficiencyLevel,
+  BlogImageType,
+  CertificationStatus,
+  InquiryType,
+  SubmissionStatus,
+} from './enums';
+
+// ============================================================================
+// Auth
+// ============================================================================
+
+export interface AuthResponse {
+  token: string;
+  tokenType: string;
+  expiresIn: number;
+  username: string;
+  role: string;
+}
+
+// ============================================================================
+// Projects
+// ============================================================================
+
+export interface ProjectResponse {
+  id: number;
+  name: string;
+  slug: string;
+  shortDescription: string;
+  fullDescription: string | null;
+  type: ProjectType;
+  status: ProjectStatus;
+  difficultyLevel: DifficultyLevel | null;
+  startDate: string | null;
+  completionDate: string | null;
+  estimatedHours: number | null;
+  published: boolean;
+  featured: boolean;
+  displayOrder: number;
+  viewCount: number;
+  technologies: TechnologyResponse[];
+  images: ProjectImageResponse[];
+  links: ProjectLinkResponse[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectImageResponse {
+  id: number;
+  projectId: number;
+  projectName: string;
+  url: string;
+  cloudinaryPublicId: string;
+  altText: string | null;
+  caption: string | null;
+  imageType: ImageType;
+  displayOrder: number;
+  isPrimary: boolean;
+  createdAt: string;
+}
+
+export interface ProjectLinkResponse {
+  id: number;
+  type: LinkType;
+  url: string;
+  label: string | null;
+  displayOrder: number;
+  createdAt: string;
+}
+
+// ============================================================================
+// Technologies
+// ============================================================================
+
+export interface TechnologyResponse {
+  id: number;
+  name: string;
+  version: string | null;
+  category: TechnologyCategory;
+  iconUrl: string | null;
+  color: string | null;
+  documentationUrl: string | null;
+  proficiencyLevel: ProficiencyLevel | null;
+  yearsExperience: number | null;
+  featured: boolean;
+  projectCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================================================
+// Certifications
+// ============================================================================
+
+export interface CertificationResponse {
+  id: number;
+  name: string;
+  slug: string;
+  issuingOrganization: string;
+  credentialId: string | null;
+  credentialUrl: string | null;
+  issueDate: string | null;
+  expirationDate: string | null;
+  status: CertificationStatus;
+  description: string | null;
+  badgeUrl: string | null;
+  published: boolean;
+  featured: boolean;
+  displayOrder: number;
+  technologies: TechnologyResponse[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================================================
+// Blog
+// ============================================================================
+
+export interface BlogPostResponse {
+  id: number;
+  title: string;
+  slug: string;
+  content: string;
+  excerpt: string | null;
+  published: boolean;
+  publishedAt: string | null;
+  viewCount: number;
+  readTimeMinutes: number | null;
+  categories: BlogCategoryResponse[];
+  tags: BlogTagResponse[];
+  images: BlogPostImageResponse[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BlogCategoryResponse {
+  id: number;
+  name: string;
+  slug: string;
+  description: string | null;
+  color: string | null;
+  postCount: number;
+  createdAt: string;
+}
+
+export interface BlogTagResponse {
+  id: number;
+  name: string;
+  slug: string;
+  usageCount: number;
+  createdAt: string;
+}
+
+export interface BlogPostImageResponse {
+  id: number;
+  url: string;
+  cloudinaryPublicId: string;
+  altText: string | null;
+  caption: string | null;
+  imageType: BlogImageType;
+  displayOrder: number;
+  isPrimary: boolean;
+  createdAt: string;
+}
+
+// ============================================================================
+// Contact
+// ============================================================================
+
+export interface ContactSubmissionResponse {
+  id: number;
+  name: string;
+  email: string;
+  subject: string | null;
+  message: string;
+  inquiryType: InquiryType | null;
+  status: SubmissionStatus;
+  ipAddress: string | null;
+  userAgent: string | null;
+  createdAt: string;
+  respondedAt: string | null;
+}
+
+// ============================================================================
+// Resume
+// ============================================================================
+
+export interface ResumeResponse {
+  fileName: string;
+  fileUrl: string;
+  fileSize: number;
+  contentType: string;
+  uploadedAt: string;
+  updatedAt: string;
+}
+
+// ============================================================================
+// Operations
+// ============================================================================
+
+export interface HealthResponse {
+  status: string;
+  service: string;
+  timestamp: string;
+  version: string;
+  environment: string;
+}


### PR DESCRIPTION
## Summary
- Created TypeScript interfaces for all 11 backend enums (using `as const` + derived union types)
- Added all 13 response DTOs and 21 request DTOs matching backend exactly
- Enhanced Axios client with JWT request interceptor, response envelope unwrapping, and structured error handling
- Built 7 typed API service modules: auth, projects, technologies, certifications, blog, contact, resume

Closes #3

## Test plan
- [ ] `npm run build` passes with no TypeScript errors
- [ ] No `enum` keyword used (compliant with `erasableSyntaxOnly`)
- [ ] All type-only imports use `import type` (compliant with `verbatimModuleSyntax`)
- [ ] All types match CLAUDE.md DTO definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)