### PR TITLE
Project detail page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,13 +122,14 @@ POST /auth/login  { username, password } -> AuthResponse
 GET    /projects                                          -> Response<List<ProjectResponse>>
 GET    /projects/paginated?page&size&sort&published       -> Response<Page<ProjectResponse>>
 GET    /projects/{id}                                     -> Response<ProjectResponse>
+GET    /projects/slug/{slug}                              -> Response<ProjectResponse>
 GET    /projects/technology/{tech}                        -> Response<List<ProjectResponse>>
 GET    /projects/featured                                 -> Response<List<ProjectResponse>>
 POST   /projects                                          -> Response<ProjectResponse>        [ADMIN]
 PUT    /projects/{id}                                     -> Response<ProjectResponse>        [ADMIN]
 DELETE /projects/{id}                                     -> Response<Void>                   [ADMIN]
 ```
-Note: Use `?published=true` on the paginated endpoint for public-facing pages. There is no `/projects/slug/{slug}` or `/projects/published` endpoint.
+Note: Use `?published=true` on the paginated endpoint for public-facing pages. There is no `/projects/published` endpoint.
 
 ### Project Images
 ```

--- a/docs/learning/react/useCallback.md
+++ b/docs/learning/react/useCallback.md
@@ -1,0 +1,263 @@
+# useCallback
+
+## What It Is
+
+`useCallback` returns a **memoized version** of a function — meaning React gives you
+back the same function reference across re-renders, instead of creating a new one
+every time.
+
+```tsx
+const memoizedFn = useCallback((args) => {
+  // function body
+}, [dependencies]);
+```
+
+- **Function** — the function you want to stabilize
+- **Dependency array** — when these values change, React creates a new function
+- **Return value** — a stable reference to that function
+
+## Why Functions Need Stabilizing
+
+In JavaScript, every time your component renders, all functions defined inside it
+are **recreated** — they look the same but are different objects in memory:
+
+```tsx
+function MyComponent() {
+  // This is a BRAND NEW function object on every render
+  const handleClick = () => console.log('clicked');
+
+  // Even though the code is identical, this is !== from the last render's version
+}
+```
+
+Most of the time, this doesn't matter. But it matters in two cases:
+
+1. **When the function is a useEffect dependency** — a new reference triggers the effect
+2. **When the function is passed as a prop to a memoized child** — a new reference
+   causes the child to re-render unnecessarily
+
+## Java Analogy
+
+Think of it like **caching a lambda or method reference** instead of creating a new
+anonymous class instance on each call:
+
+```java
+// Java: new anonymous instance every time — different object each call
+Runnable getHandler() {
+    return () -> System.out.println("click");  // new object each call
+}
+
+// Java: cached — same instance returned each time
+private final Runnable handler = () -> System.out.println("click");
+Runnable getHandler() {
+    return handler;  // same reference every time
+}
+```
+
+`useCallback` is React's version of that caching. It says: "Don't recreate this
+function unless one of its dependencies changed."
+
+## The One Real Example in This Project
+
+### Stabilized fetch function (ProjectsPage)
+
+```tsx
+// src/pages/ProjectsPage.tsx
+
+const fetchPage = useCallback((pageNum: number, append: boolean) => {
+  if (append) {
+    setLoadingMore(true);
+  } else {
+    setLoading(true);
+  }
+  setError(null);
+
+  projectApi
+    .getPaginated({ page: pageNum, size: PAGE_SIZE, sort: 'displayOrder,asc', published: true })
+    .then((data) => {
+      setProjects((prev) => (append ? [...prev, ...data.content] : data.content));
+      setHasMore(data.page.number < data.page.totalPages - 1);
+      setPage(pageNum);
+    })
+    .catch(() => setError('Failed to load projects.'))
+    .finally(() => {
+      setLoading(false);
+      setLoadingMore(false);
+    });
+}, []);
+
+useEffect(() => {
+  fetchPage(0, false);
+}, [fetchPage]);
+```
+
+**What's happening step by step:**
+
+1. `fetchPage` is wrapped in `useCallback` with `[]` (no dependencies)
+2. This means `fetchPage` is created **once** and the same reference is reused
+3. `useEffect` lists `[fetchPage]` as its dependency
+4. Since `fetchPage` never changes (stable reference), the effect only runs once
+5. The same `fetchPage` function is also used in the "Load More" button's onClick
+
+**Why `[]` works here:** The function only uses `setProjects`, `setLoading`, etc. —
+React guarantees that state setter functions (`setState`) have **stable references**.
+They never change, so they don't need to be in the dependency array.
+
+**Why not just use `useEffect` with `[]` directly?**
+
+```tsx
+// This would also work:
+useEffect(() => {
+  projectApi.getPaginated(...)
+    .then(...)
+    .catch(...)
+    .finally(...);
+}, []);
+```
+
+The reason for extracting into `useCallback` is **reuse** — `fetchPage` is called in
+two places:
+1. The `useEffect` for initial load: `fetchPage(0, false)`
+2. The "Load More" button: `onClick={() => fetchPage(page + 1, true)}`
+3. The error retry: `onRetry={() => fetchPage(0, false)}`
+
+Without `useCallback`, you'd either duplicate the fetch logic or define it outside
+the effect and have the linter complain about missing dependencies.
+
+## When You DON'T Need useCallback
+
+Most of the time. The project's other functions don't use it, and that's correct:
+
+```tsx
+// HomePage — retry handler defined inline, no useCallback needed
+const retryTechnologies = () => {
+  setTechError(null);
+  setTechLoading(true);
+  technologyApi.getFeatured()
+    .then((data) => setTechnologies(data))
+    .catch(() => setTechError('Failed to load technologies.'))
+    .finally(() => setTechLoading(false));
+};
+```
+
+This function is recreated on every render. That's fine because:
+- It's not in any dependency array
+- It's not passed to a memoized child component
+- The cost of creating a function is negligible
+
+**Rule of thumb:** Don't add `useCallback` unless you have a specific reason (it's a
+dependency of `useEffect`, or it's a prop to a `React.memo` child). Premature
+memoization adds complexity with no benefit.
+
+## useCallback vs useMemo
+
+They're closely related:
+
+```tsx
+// useCallback — memoizes a FUNCTION
+const fn = useCallback(() => doSomething(a, b), [a, b]);
+
+// useMemo — memoizes a VALUE (the result of calling a function)
+const value = useMemo(() => expensiveCalculation(a, b), [a, b]);
+```
+
+In fact, `useCallback(fn, deps)` is equivalent to `useMemo(() => fn, deps)`.
+
+- Use `useCallback` when you need a **stable function reference**
+- Use `useMemo` when you need to **cache an expensive computation**
+
+This project doesn't use `useMemo` yet. The filtered projects list in
+`TechnologyShowcase` and `ProjectsPage` is computed directly during render, which is
+fine — filtering a small array is cheap. You'd reach for `useMemo` if filtering
+thousands of items caused visible lag.
+
+## The Dependency Array
+
+Same rules as `useEffect`:
+
+```tsx
+// Empty [] — function is created once, never recreated
+const fetchPage = useCallback((pageNum) => {
+  // can safely use setState functions (they're stable)
+  setProjects(data);
+}, []);
+
+// With deps — function is recreated when deps change
+const search = useCallback((query) => {
+  api.search(query, activeFilter);  // uses activeFilter from state
+}, [activeFilter]);  // recreate when filter changes
+```
+
+If you use a value from outside the function (props, state) inside the callback,
+it must be in the dependency array. Otherwise you get **stale closures** — the
+function captures an old value and never sees updates.
+
+## Common Mistakes
+
+### 1. Using useCallback everywhere "for performance"
+```tsx
+// UNNECESSARY — no benefit, adds complexity
+const handleClick = useCallback(() => {
+  setOpen(!open);
+}, [open]);
+
+// JUST DO THIS
+const handleClick = () => setOpen(!open);
+```
+`useCallback` itself has a cost (comparing dependencies). Only use it when you
+have a real need.
+
+### 2. Missing dependencies → stale closure
+```tsx
+// BUG — always uses the initial value of `page`
+const loadMore = useCallback(() => {
+  fetchPage(page + 1);    // page is always 0!
+}, []);                    // ← page missing from deps
+
+// FIX
+const loadMore = useCallback(() => {
+  fetchPage(page + 1);
+}, [page]);                // ← recreates when page changes
+```
+
+Note: in `ProjectsPage`, this is avoided by passing `page` as an **argument** to
+`fetchPage` rather than closing over it. That's a smart pattern — it keeps the
+dependency array empty.
+
+### 3. Confusing useCallback with useMemo
+```tsx
+// WRONG — this memoizes the function, not its result
+const filtered = useCallback(() => {
+  return items.filter(i => i.active);
+}, [items]);
+// filtered is a FUNCTION, not the filtered array!
+
+// RIGHT — useMemo memoizes the result
+const filtered = useMemo(() => {
+  return items.filter(i => i.active);
+}, [items]);
+// filtered is the filtered array
+```
+
+## Interview Talking Points
+
+1. **"useCallback memoizes a function reference across renders."** Without it,
+   functions are recreated on every render. Usually that's fine, but it matters
+   when the function is a dependency of useEffect or a prop to a memoized component.
+
+2. **"I use it primarily to stabilize useEffect dependencies."** The main use case
+   in this project — wrapping `fetchPage` so the effect that depends on it doesn't
+   re-run unnecessarily.
+
+3. **"I don't use it by default — only when there's a concrete need."** Premature
+   memoization is a code smell. The cost of creating functions is nearly zero;
+   the cost of unnecessary complexity is real.
+
+4. **"The dependency array works the same as useEffect."** List the external values
+   the function closes over. React recreates the function when those values change.
+   State setters are stable and don't need to be listed.
+
+5. **"A good alternative is passing values as arguments instead of closing over
+   them."** In `ProjectsPage`, `fetchPage(pageNum)` takes the page number as a
+   parameter rather than reading `page` from state. This keeps dependencies empty
+   and avoids stale closures.

--- a/docs/learning/react/useEffect.md
+++ b/docs/learning/react/useEffect.md
@@ -1,0 +1,292 @@
+# useEffect
+
+## What It Is
+
+`useEffect` lets you run **side effects** — code that interacts with the world outside
+your component. Fetching data, updating the document title, setting up event listeners,
+scrolling the window — these are all side effects.
+
+```tsx
+useEffect(() => {
+  // effect code runs AFTER render
+  return () => {
+    // cleanup code runs before next effect or unmount (optional)
+  };
+}, [dependencies]);
+```
+
+- **Effect function** — runs after React paints the screen
+- **Cleanup function** — optional return value; cleans up the previous effect
+- **Dependency array** — controls WHEN the effect re-runs
+
+## Java Analogy
+
+`useEffect` is like **lifecycle callbacks** in Java frameworks:
+
+| useEffect pattern | Java equivalent |
+|---|---|
+| `useEffect(() => {...}, [])` | `@PostConstruct` — runs once after initialization |
+| `useEffect(() => {...}, [dep])` | A `PropertyChangeListener` that fires when `dep` changes |
+| `useEffect(() => { return () => {...} }, [])` | `@PreDestroy` — cleanup before removal |
+
+```java
+// Java: lifecycle hooks
+@Component
+class ProjectService {
+    @PostConstruct           // ← like useEffect(..., [])
+    void init() {
+        loadProjects();
+    }
+
+    @PreDestroy              // ← like the cleanup function
+    void cleanup() {
+        closeConnections();
+    }
+}
+```
+
+```tsx
+// React: useEffect
+function ProjectsPage() {
+  useEffect(() => {
+    loadProjects();          // ← runs once on mount
+    return () => {
+      cancelRequests();      // ← runs on unmount
+    };
+  }, []);
+}
+```
+
+## The Dependency Array Is Everything
+
+The dependency array is the most important (and most confusing) part. It answers:
+**"When should this effect re-run?"**
+
+### Empty array `[]` — run once on mount
+```tsx
+useEffect(() => {
+  fetchProjects();    // fetch data when component first appears
+}, []);
+```
+This is the most common pattern for data fetching. The effect runs once, after the
+first render, and never again.
+
+### With dependencies `[a, b]` — run when values change
+```tsx
+useEffect(() => {
+  document.title = title ? `${title} | Casey Quinn` : 'Casey Quinn | Portfolio';
+}, [title]);
+```
+React compares each dependency to its value from the previous render. If any changed,
+the effect runs again. Here, the title updates whenever the `title` argument changes.
+
+### No array at all — run on EVERY render
+```tsx
+useEffect(() => {
+  console.log('I run after every single render');
+});
+```
+Almost never what you want. If you call `setState` inside this, you get an
+**infinite loop**: render → effect → setState → render → effect → setState → ...
+
+## Real Examples From This Project
+
+### Data fetching on mount (HomePage)
+
+```tsx
+// src/pages/HomePage.tsx
+useEffect(() => {
+  projectApi
+    .getFeatured()
+    .then((data) => setProjects(data))
+    .catch(() => setProjectsError('Failed to load projects.'))
+    .finally(() => setProjectsLoading(false));
+}, []);
+```
+
+**Walk through the timeline:**
+1. Component renders with initial state: `projects=[]`, `loading=true`, `error=null`
+2. React paints the loading spinner to the screen
+3. `useEffect` fires, kicks off the API call
+4. API responds → `setProjects(data)` and `setProjectsLoading(false)` are called
+5. React re-renders with the data, replaces spinner with project cards
+
+**Why `[]`?** We only want to fetch once when the page loads. If we put `projects` in
+the dependency array, setting projects would trigger the effect again → infinite loop.
+
+### Setting the page title (usePageTitle hook)
+
+```tsx
+// src/hooks/usePageTitle.ts
+export function usePageTitle(title: string) {
+  useEffect(() => {
+    document.title = title ? `${title} | Casey Quinn` : 'Casey Quinn | Portfolio';
+  }, [title]);
+}
+```
+
+**Why `[title]`?** The title should update whenever the `title` argument changes.
+For most pages this only runs once (title is a static string like `'Projects'`).
+For `ProjectDetailPage`, it could change if the slug changes.
+
+`document.title` is a side effect — it modifies something outside React's world (the
+browser tab). That's exactly what `useEffect` is for.
+
+### Scroll to top on navigation (useScrollToTop hook)
+
+```tsx
+// src/hooks/useScrollToTop.ts
+export function useScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+}
+```
+
+**Why `[pathname]`?** We want to scroll to top every time the user navigates to a
+different page. `pathname` changes on navigation (`/projects` → `/projects/my-app`),
+which triggers the effect.
+
+Without this hook, clicking a link at the bottom of a page would load the new page
+scrolled to the bottom — bad UX.
+
+### Fetching with a callback dependency (ProjectsPage)
+
+```tsx
+// src/pages/ProjectsPage.tsx
+const fetchPage = useCallback((pageNum: number, append: boolean) => {
+  // ...fetch logic...
+}, []);
+
+useEffect(() => {
+  fetchPage(0, false);
+}, [fetchPage]);
+```
+
+**Why `[fetchPage]`?** The linter requires you to list all values used inside the
+effect. Since `fetchPage` is created with `useCallback` and an empty dependency
+array, its reference is **stable** — it never changes, so this effect only runs once.
+It's equivalent to `[]` but satisfies the exhaustive-deps lint rule.
+
+## The Cleanup Function
+
+The cleanup function runs in two scenarios:
+1. **Before the effect re-runs** (when dependencies change)
+2. **When the component unmounts** (removed from the page)
+
+This project doesn't use cleanup yet, but here's when you'd need it:
+
+```tsx
+// Example: subscribing to window resize
+useEffect(() => {
+  const handleResize = () => setWidth(window.innerWidth);
+  window.addEventListener('resize', handleResize);
+
+  return () => {
+    window.removeEventListener('resize', handleResize);  // cleanup!
+  };
+}, []);
+```
+
+Without cleanup, every re-render would add another event listener — a **memory leak**.
+Java analogy: this is like closing a stream in a `finally` block or implementing
+`AutoCloseable`.
+
+### Cleanup with API calls
+A common real-world pattern — canceling a fetch if the component unmounts before
+the response arrives:
+
+```tsx
+useEffect(() => {
+  const controller = new AbortController();
+
+  fetch('/api/projects', { signal: controller.signal })
+    .then(res => res.json())
+    .then(data => setProjects(data))
+    .catch(err => {
+      if (err.name !== 'AbortError') setError('Failed');
+    });
+
+  return () => controller.abort();  // cancel if we navigate away
+}, []);
+```
+
+This project doesn't do this yet (the API client uses `.then()` chains without
+abort), but it's a good interview topic — you can discuss it as a potential
+improvement.
+
+## Common Mistakes
+
+### 1. Missing dependency → stale values
+```tsx
+// BUG — count is always 0 inside the effect
+const [count, setCount] = useState(0);
+useEffect(() => {
+  const id = setInterval(() => {
+    console.log(count);  // always 0! captured the initial value
+  }, 1000);
+  return () => clearInterval(id);
+}, []);  // ← count is missing from deps
+
+// FIX — add count to deps, or use functional updater
+```
+
+### 2. Object/array in dependency array → infinite loop
+```tsx
+// BUG — new object every render, effect runs every time
+useEffect(() => {
+  fetchData(filters);
+}, [{ status: 'active' }]);  // ← new object reference each render
+
+// FIX — use primitives or useMemo
+useEffect(() => {
+  fetchData(status);
+}, [status]);  // ← string comparison, stable
+```
+
+### 3. Fetching without guarding state updates
+```tsx
+// BUG — if component unmounts before fetch completes, setState on
+// an unmounted component (React warns about this)
+useEffect(() => {
+  fetchData().then(data => setData(data));  // might be unmounted!
+}, []);
+
+// FIX — use an abort controller (see cleanup section above)
+```
+
+## useEffect vs Event Handlers
+
+A common interview question: **"When should you use useEffect vs an event handler?"**
+
+| Use useEffect when... | Use an event handler when... |
+|---|---|
+| The code should run because something **appeared or changed** | The code should run because the user **did something** |
+| Fetching data when a page loads | Fetching data when a button is clicked |
+| Updating the document title | Submitting a form |
+| Setting up a subscription | Toggling a menu |
+
+In this project, initial data fetching uses `useEffect` (runs on mount), but the
+"Load More" button uses an event handler (`onClick={() => fetchPage(page + 1, true)}`).
+Same fetch function, different trigger.
+
+## Interview Talking Points
+
+1. **"useEffect synchronizes your component with an external system."** It's for side
+   effects — anything outside React's rendering: DOM manipulation, API calls, timers.
+
+2. **"The dependency array controls when the effect re-runs."** Empty = once on mount.
+   With values = when those values change. Missing = every render (usually a bug).
+
+3. **"Effects run after render, not during."** React paints the screen first, then
+   runs effects. This keeps the UI responsive — the user sees content immediately
+   while background work happens after.
+
+4. **"Cleanup prevents memory leaks."** The returned function cleans up subscriptions,
+   timers, or in-flight requests. Like `@PreDestroy` or `AutoCloseable` in Java.
+
+5. **"Not everything needs useEffect."** Derived values (filtering, mapping) should
+   be computed during render, not in an effect. Effects are for synchronizing with
+   things outside React.

--- a/docs/learning/react/useState.md
+++ b/docs/learning/react/useState.md
@@ -1,0 +1,197 @@
+# useState
+
+## What It Is
+
+`useState` is React's way of giving a component **memory**. Without it, every time React
+re-renders your component (which happens often), all local variables reset to their
+initial values. `useState` preserves values across renders.
+
+```tsx
+const [value, setValue] = useState(initialValue);
+```
+
+- `value` — the current state
+- `setValue` — a function to update it (triggers a re-render)
+- `initialValue` — what it starts as (only used on first render)
+
+## Java Analogy
+
+Think of a React component like a method that gets called over and over. Normally,
+local variables inside a method don't survive between calls. `useState` is like
+promoting a local variable to an **instance field** — it persists across invocations.
+
+```java
+// Java: instance field persists across method calls
+class ProjectList {
+    private List<Project> projects = new ArrayList<>();  // ← persists
+    private boolean loading = true;                       // ← persists
+
+    public void render() {
+        // uses this.projects, this.loading
+    }
+}
+```
+
+```tsx
+// React: useState persists across re-renders
+function ProjectList() {
+  const [projects, setProjects] = useState([]);    // ← persists
+  const [loading, setLoading] = useState(true);     // ← persists
+
+  return (/* uses projects, loading */);
+}
+```
+
+The key difference: in Java you mutate the field directly (`this.loading = false`).
+In React you **must** use the setter (`setLoading(false)`) because that's what tells
+React "something changed, re-render this component."
+
+## How It Works Under the Hood
+
+1. You call `setLoading(false)`
+2. React schedules a re-render of your component
+3. Your entire function runs again from top to bottom
+4. This time, `useState(true)` returns `false` (the updated value, not the initial)
+5. React compares the new JSX output with the old one and updates only what changed in the DOM
+
+This is why you can't just do `loading = false` — React wouldn't know anything changed.
+
+## Real Examples From This Project
+
+### Simple toggle state (Navbar)
+The simplest use case — a boolean that flips between true/false:
+
+```tsx
+// src/components/layout/Navbar.tsx
+const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+// Toggle it:
+<button onClick={() => setMobileMenuOpen(!mobileMenuOpen)}>
+  Menu
+</button>
+
+// Use it for conditional rendering:
+{mobileMenuOpen && <nav>...mobile links...</nav>}
+```
+
+### Tab selection state (TechnologyShowcase)
+Storing which tab index is active:
+
+```tsx
+// src/components/ui/TechnologyShowcase.tsx
+const [activeTab, setActiveTab] = useState(0);   // 0 = Backend tab
+
+// Tab button sets the index:
+<button onClick={() => setActiveTab(index)}>
+  {group.label}
+</button>
+
+// Derived data — filter based on active tab (no extra state needed):
+const filteredTechs = technologies.filter((tech) =>
+  activeGroup.categories.includes(tech.category)
+);
+```
+
+**Key insight:** `filteredTechs` is **derived state** — it's computed from `activeTab`
+and `technologies` on every render. You don't need a separate `useState` for it.
+This is like computing a value from fields in Java rather than storing a redundant copy.
+
+### Data fetching trifecta (HomePage)
+The most common pattern — three related state variables for async data:
+
+```tsx
+// src/pages/HomePage.tsx
+const [projects, setProjects] = useState<ProjectResponse[]>([]);
+const [projectsLoading, setProjectsLoading] = useState(true);
+const [projectsError, setProjectsError] = useState<string | null>(null);
+```
+
+These three always travel together because any async operation has three possible
+states: **loading**, **success** (has data), or **failure** (has error).
+
+Java analogy: this is like the three states of a `CompletableFuture<T>`:
+- Pending → `loading = true`
+- Completed → `loading = false`, data populated
+- Failed → `loading = false`, error populated
+
+### Pagination state (ProjectsPage)
+Multiple related state variables working together:
+
+```tsx
+// src/pages/ProjectsPage.tsx
+const [projects, setProjects] = useState<ProjectResponse[]>([]);
+const [loading, setLoading] = useState(true);
+const [loadingMore, setLoadingMore] = useState(false);   // separate from initial load
+const [error, setError] = useState<string | null>(null);
+const [hasMore, setHasMore] = useState(false);
+const [page, setPage] = useState(0);
+const [activeCategory, setActiveCategory] = useState<TechnologyCategory | null>(null);
+```
+
+Notice `loading` vs `loadingMore` — two separate booleans because the UI treats
+initial load (show spinner) differently from loading the next page (show "Loading..."
+on button). This is a real-world nuance you'd discuss in an interview.
+
+## Updating State Based on Previous State
+
+When your new value depends on the old value, use the **functional updater** form:
+
+```tsx
+// From ProjectsPage — appending new projects to existing ones:
+setProjects((prev) => [...prev, ...data.content]);
+```
+
+Why not `setProjects([...projects, ...data.content])`? Because `projects` might be
+stale — if multiple updates are batched, `projects` still holds the value from the
+start of the render. The functional form `(prev) => ...` always gets the latest value.
+
+Java analogy: this is like `AtomicReference.updateAndGet(prev -> ...)` — you operate
+on the guaranteed-current value, not a potentially stale reference.
+
+## Common Mistakes
+
+### 1. Mutating state directly
+```tsx
+// WRONG — React won't know anything changed
+projects.push(newProject);
+setProjects(projects);  // same reference, React skips re-render
+
+// RIGHT — create a new array
+setProjects([...projects, newProject]);
+```
+React uses **reference equality** to detect changes. You need a new object/array.
+Java analogy: like how `HashMap` needs a new key object if you change equality — same
+concept of identity vs. equality.
+
+### 2. Too many useState calls for related data
+If you have 5+ related state variables (like the data fetching trifecta + pagination),
+consider whether `useReducer` might be cleaner. But for this project's scale,
+individual `useState` calls are fine and more readable.
+
+### 3. Storing derived state
+```tsx
+// WRONG — redundant state that can get out of sync
+const [filteredProjects, setFilteredProjects] = useState([]);
+
+// RIGHT — compute it on every render (it's cheap)
+const filteredProjects = projects.filter(...);
+```
+
+## Interview Talking Points
+
+1. **"useState gives components memory across re-renders."** Your component function
+   runs on every render. Without useState, variables reset each time.
+
+2. **"The setter triggers a re-render."** This is the core mechanism — calling
+   `setState` tells React the UI might have changed.
+
+3. **"State updates are asynchronous and batched."** React doesn't update immediately.
+   It batches multiple `setState` calls and re-renders once. This is why you use the
+   functional updater `setState(prev => ...)` when the new value depends on the old.
+
+4. **"I prefer derived state over redundant state."** Instead of syncing two pieces
+   of state, compute one from the other. Fewer bugs, simpler code.
+
+5. **"For async data, I use the loading/error/data trifecta pattern."** Three state
+   variables that model the three states of an async operation. This is the standard
+   pattern before adopting libraries like React Query.

--- a/github_issues/issues.md
+++ b/github_issues/issues.md
@@ -192,7 +192,7 @@ Build the projects listing page with category-based filtering.
 Build the individual project detail page.
 
 **Tasks:**
-- [ ] Fetch project by slug: `GET /api/v1/projects/slug/:slug`
+- [ ] Fetch project by slug: `GET /api/v1/projects/slug/{slug}`
 - [ ] Hero image section (primary project image)
 - [ ] Project metadata: status badge, difficulty, type, dates, estimated hours
 - [ ] Full description rendered as formatted text

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -27,6 +27,9 @@ export const projectApi = {
   getById: (id: number) =>
     apiGet<ProjectResponse>(`/projects/${id}`),
 
+  getBySlug: (slug: string) =>
+    apiGet<ProjectResponse>(`/projects/slug/${slug}`),
+
   getByTechnology: (tech: string) =>
     apiGet<ProjectResponse[]>(`/projects/technology/${tech}`),
 

--- a/src/components/ui/ProjectGallery.tsx
+++ b/src/components/ui/ProjectGallery.tsx
@@ -1,0 +1,101 @@
+import type { ProjectImageResponse } from '@/types';
+
+interface ProjectGalleryProps {
+  images: ProjectImageResponse[];
+}
+
+export function ProjectGallery({ images }: ProjectGalleryProps) {
+  if (images.length === 0) return null;
+
+  return (
+    <section className="max-w-7xl mx-auto px-8 mt-32 space-y-12">
+      <div className="flex items-end justify-between">
+        <h2 className="text-4xl font-headline font-bold tracking-tight">
+          System <span className="text-primary italic">Snapshots</span>
+        </h2>
+        <span className="text-on-surface-variant text-sm font-label tracking-widest">
+          {images.length} {images.length === 1 ? 'IMAGE' : 'IMAGES'}
+        </span>
+      </div>
+
+      {/* Adaptive grid based on image count */}
+      <div className={`grid gap-4 ${
+        images.length === 1
+          ? 'grid-cols-1 h-[400px]'
+          : images.length === 2
+            ? 'grid-cols-1 md:grid-cols-2 h-[400px]'
+            : 'grid-cols-1 md:grid-cols-12 h-[800px] md:h-[600px]'
+      }`}>
+        {images.length >= 3 ? (
+          <>
+            {/* Large featured image */}
+            <div className="md:col-span-8 overflow-hidden rounded-xl border border-white/5 relative group">
+              <img
+                src={images[0].url}
+                alt={images[0].altText ?? 'Project screenshot'}
+                className="w-full h-full object-cover grayscale opacity-60 group-hover:grayscale-0 group-hover:opacity-100 transition-all duration-700"
+              />
+              {images[0].caption && (
+                <div className="absolute bottom-6 left-6 bg-background/80 backdrop-blur-md px-4 py-2 rounded border border-white/10 text-xs tracking-widest font-bold uppercase">
+                  {images[0].caption}
+                </div>
+              )}
+            </div>
+            {/* Stacked smaller images */}
+            <div className="md:col-span-4 grid grid-rows-2 gap-4">
+              {images.slice(1, 3).map((img: ProjectImageResponse) => (
+                <GalleryImage key={img.id} image={img} />
+              ))}
+            </div>
+          </>
+        ) : (
+          /* 1 or 2 images — simple equal grid */
+          images.map((img: ProjectImageResponse) => (
+            <GalleryImage key={img.id} image={img} />
+          ))
+        )}
+      </div>
+
+      {/* Overflow images beyond the first 3 */}
+      {images.length > 3 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {images.slice(3).map((img: ProjectImageResponse) => (
+            <div key={img.id} className="aspect-video overflow-hidden rounded-xl border border-white/5 group relative">
+              <img
+                src={img.url}
+                alt={img.altText ?? 'Project screenshot'}
+                className="w-full h-full object-cover grayscale opacity-60 group-hover:grayscale-0 group-hover:opacity-100 transition-all duration-700"
+              />
+              {img.caption && (
+                <div className="absolute bottom-4 left-4 bg-background/80 backdrop-blur-md px-3 py-1.5 rounded border border-white/10 text-xs tracking-widest font-bold uppercase">
+                  {img.caption}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ============================================================================
+// Internal sub-component for repeated image card pattern
+// ============================================================================
+
+function GalleryImage({ image }: { image: ProjectImageResponse }) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-white/5 group relative">
+      <img
+        src={image.url}
+        alt={image.altText ?? 'Project screenshot'}
+        className="w-full h-full object-cover grayscale opacity-60 group-hover:grayscale-0 group-hover:opacity-100 transition-all duration-700"
+      />
+      {image.caption && (
+        <div className="absolute bottom-4 left-4 bg-background/80 backdrop-blur-md px-3 py-1.5 rounded border border-white/10 text-xs tracking-widest font-bold uppercase">
+          {image.caption}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/ProjectLinks.tsx
+++ b/src/components/ui/ProjectLinks.tsx
@@ -1,0 +1,145 @@
+import type { ProjectLinkResponse, LinkType } from '@/types';
+
+// ============================================================================
+// Link type configuration — icon + label for each LinkType enum value
+// ============================================================================
+
+interface LinkConfig {
+  label: string;
+  icon: React.ReactNode;
+}
+
+const LINK_ICONS: Record<LinkType, LinkConfig> = {
+  GITHUB: {
+    label: 'GitHub Repository',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+      </svg>
+    ),
+  },
+  LIVE: {
+    label: 'Live Site',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /><polyline points="15 3 21 3 21 9" /><line x1="10" y1="14" x2="21" y2="3" />
+      </svg>
+    ),
+  },
+  DEMO: {
+    label: 'Live Demo',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polygon points="5 3 19 12 5 21 5 3" />
+      </svg>
+    ),
+  },
+  STAGING: {
+    label: 'Staging',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="2" y="3" width="20" height="14" rx="2" ry="2" /><line x1="8" y1="21" x2="16" y2="21" /><line x1="12" y1="17" x2="12" y2="21" />
+      </svg>
+    ),
+  },
+  DOCUMENTATION: {
+    label: 'Documentation',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" /><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+      </svg>
+    ),
+  },
+  DOCKER: {
+    label: 'Docker Hub',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M22 12.5c-.5-1-1.5-1.5-2.5-1.5h-1v-2h-2v2h-2v-2h-2v2h-2v-2H8v2H6V9H4v2H2.5C1.5 11 .5 11.5 0 12.5" /><rect x="5" y="14" width="14" height="7" rx="1" />
+      </svg>
+    ),
+  },
+  NPM: {
+    label: 'NPM Package',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M20 4H4v16h8V8h4v12h4V4z" />
+      </svg>
+    ),
+  },
+  MAVEN: {
+    label: 'Maven Central',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+      </svg>
+    ),
+  },
+  API: {
+    label: 'API Reference',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" />
+      </svg>
+    ),
+  },
+  OTHER: {
+    label: 'Link',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" /><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+      </svg>
+    ),
+  },
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+interface ProjectLinksProps {
+  links: ProjectLinkResponse[];
+}
+
+export function ProjectLinks({ links }: ProjectLinksProps) {
+  if (links.length === 0) return null;
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-xl font-bold text-on-surface font-headline">
+        Repository & Deployment
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {links.map((link: ProjectLinkResponse, index: number) => {
+          const config: LinkConfig = LINK_ICONS[link.type] ?? LINK_ICONS.OTHER;
+          const isFirst: boolean = index === 0;
+
+          return (
+            <a
+              key={link.id}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`flex items-center justify-between px-6 py-4 rounded-lg group transition-all hover:scale-[1.02] ${
+                isFirst
+                  ? 'bg-gradient-to-br from-primary to-primary-dim text-on-primary'
+                  : 'bg-surface-variant border border-outline-variant/30 text-on-surface hover:bg-surface-container-highest'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                {config.icon}
+                <span className="font-medium">{link.label ?? config.label}</span>
+              </div>
+              <svg
+                width="16" height="16" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+                className={`group-hover:translate-x-1 transition-transform ${isFirst ? 'opacity-70' : 'text-on-surface-variant'}`}
+              >
+                <line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" />
+              </svg>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -8,5 +8,7 @@ export { ProjectCard } from './ProjectCard';
 export { BlogPostCard } from './BlogPostCard';
 export { CertificationCard } from './CertificationCard';
 export { TechnologyShowcase } from './TechnologyShowcase';
+export { ProjectLinks } from './ProjectLinks';
+export { ProjectGallery } from './ProjectGallery';
 export { LoadingSpinner } from './LoadingSpinner';
 export { ErrorDisplay } from './ErrorDisplay';

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -1,18 +1,258 @@
-import { useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
 import { usePageTitle } from '@/hooks';
+import { projectApi } from '@/api/projects';
+import { TechPill, StatusBadge, ProjectLinks, ProjectGallery, LoadingSpinner, ErrorDisplay } from '@/components/ui';
+import { formatDate } from '@/utils';
+import type { ProjectResponse, ProjectImageResponse } from '@/types';
+
+/** Human-readable project type labels. */
+const PROJECT_TYPE_LABELS: Record<string, string> = {
+  PERSONAL: 'Personal',
+  PROFESSIONAL: 'Professional',
+  OPEN_SOURCE: 'Open Source',
+  LEARNING: 'Learning',
+  FREELANCE: 'Freelance',
+};
 
 export function ProjectDetailPage() {
   const { slug } = useParams<{ slug: string }>();
-  usePageTitle(slug ?? 'Project');
+
+  const [project, setProject] = useState<ProjectResponse | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState<boolean>(false);
+
+  usePageTitle(project?.name ?? 'Project');
+
+  useEffect(() => {
+    if (!slug) return;
+
+    setLoading(true);
+    setError(null);
+    setNotFound(false);
+
+    projectApi
+      .getBySlug(slug)
+      .then((data: ProjectResponse) => setProject(data))
+      .catch((err) => {
+        if (err?.response?.status === 404) {
+          setNotFound(true);
+        } else {
+          setError('Failed to load project.');
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [slug]);
+
+  // ---- Loading state ----
+  if (loading) {
+    return (
+      <main className="pt-32 pb-24">
+        <LoadingSpinner message="Loading project..." />
+      </main>
+    );
+  }
+
+  // ---- Error state ----
+  if (error) {
+    return (
+      <main className="pt-32 pb-24 px-8 max-w-7xl mx-auto">
+        <ErrorDisplay message={error} onRetry={() => {
+          if (slug) {
+            setLoading(true);
+            setError(null);
+            projectApi
+              .getBySlug(slug)
+              .then((data: ProjectResponse) => setProject(data))
+              .catch(() => setError('Failed to load project.'))
+              .finally(() => setLoading(false));
+          }
+        }} />
+      </main>
+    );
+  }
+
+  // ---- 404 state ----
+  if (notFound || !project) {
+    return (
+      <main className="pt-32 pb-24 px-8 max-w-7xl mx-auto text-center">
+        <h1 className="font-headline text-6xl font-bold text-on-surface tracking-tighter mb-4">
+          404
+        </h1>
+        <p className="text-on-surface-variant text-lg mb-8">
+          No project found with slug "{slug}".
+        </p>
+        <Link
+          to="/projects"
+          className="inline-flex items-center gap-2 text-primary font-semibold hover:underline"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="19" y1="12" x2="5" y2="12" /><polyline points="12 19 5 12 12 5" />
+          </svg>
+          Back to Projects
+        </Link>
+      </main>
+    );
+  }
+
+  // ---- Derived data ----
+  const images: ProjectImageResponse[] = project.images ?? [];
+  const primaryImage: ProjectImageResponse | undefined = images.find((img) => img.isPrimary) ?? images[0];
+  const galleryImages: ProjectImageResponse[] = images.filter((img) => img !== primaryImage);
+  const technologies = project.technologies ?? [];
+  const links = project.links ?? [];
 
   return (
-    <div className="mx-auto max-w-7xl px-6 py-16">
-      <h1 className="font-headline text-5xl font-bold text-on-surface tracking-tight">
-        Project: {slug}
-      </h1>
-      <p className="mt-4 text-lg text-on-surface-variant">
-        Project detail coming in Issue #7.
-      </p>
-    </div>
+    <main className="min-h-screen">
+      {/* ================================================================
+          BACK NAVIGATION
+          ================================================================ */}
+      <div className="max-w-7xl mx-auto px-8 py-6">
+        <Link
+          to="/projects"
+          className="inline-flex items-center gap-2 text-on-surface-variant hover:text-primary transition-colors group"
+        >
+          <svg
+            width="16" height="16" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+            className="group-hover:-translate-x-1 transition-transform"
+          >
+            <line x1="19" y1="12" x2="5" y2="12" /><polyline points="12 19 5 12 12 5" />
+          </svg>
+          <span className="font-label text-sm tracking-wide uppercase">Back to Projects</span>
+        </Link>
+      </div>
+
+      {/* ================================================================
+          HERO IMAGE
+          ================================================================ */}
+      {primaryImage && (
+        <section className="relative w-full h-[500px] md:h-[614px] overflow-hidden">
+          <img
+            src={primaryImage.url}
+            alt={primaryImage.altText ?? project.name}
+            className="w-full h-full object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-background/80 to-background" />
+        </section>
+      )}
+
+      {/* ================================================================
+          PROJECT IDENTITY — Badges, Title, Metadata
+          ================================================================ */}
+      <section className={`max-w-7xl mx-auto px-8 relative z-10 ${primaryImage ? '-mt-32' : 'pt-8'}`}>
+        <div className="flex flex-col gap-6">
+          {/* Badges */}
+          <div className="flex flex-wrap gap-3">
+            <StatusBadge status={project.status} />
+            {project.difficultyLevel && (
+              <StatusBadge status={project.difficultyLevel} />
+            )}
+            {project.type && (
+              <span className="bg-surface-variant text-on-surface-variant px-4 py-1 rounded-full text-[10px] font-bold tracking-[0.1em] uppercase border border-white/5">
+                {PROJECT_TYPE_LABELS[project.type] ?? project.type}
+              </span>
+            )}
+          </div>
+
+          {/* Title */}
+          <h1 className="text-5xl md:text-7xl lg:text-8xl font-headline font-bold tracking-tighter leading-none max-w-4xl">
+            {project.name.includes(' ')
+              ? (
+                <>
+                  {project.name.split(' ').slice(0, -1).join(' ')}{' '}
+                  <span className="text-primary italic">
+                    {project.name.split(' ').slice(-1)}
+                  </span>
+                </>
+              )
+              : <span className="text-primary">{project.name}</span>
+            }
+          </h1>
+
+          {/* Short description */}
+          <p className="text-on-surface-variant text-lg max-w-2xl leading-relaxed">
+            {project.shortDescription}
+          </p>
+
+          {/* Metadata row */}
+          <div className="flex flex-wrap items-center gap-x-12 gap-y-4 pt-4 border-t border-white/5 max-w-fit">
+            {project.startDate && (
+              <div className="flex flex-col">
+                <span className="text-[10px] text-on-surface-variant uppercase tracking-widest mb-1">Start Date</span>
+                <span className="font-headline text-lg font-medium">{formatDate(project.startDate)}</span>
+              </div>
+            )}
+            {project.completionDate && (
+              <div className="flex flex-col">
+                <span className="text-[10px] text-on-surface-variant uppercase tracking-widest mb-1">Completed</span>
+                <span className="font-headline text-lg font-medium">{formatDate(project.completionDate)}</span>
+              </div>
+            )}
+            {project.estimatedHours != null && (
+              <div className="flex flex-col">
+                <span className="text-[10px] text-on-surface-variant uppercase tracking-widest mb-1">Estimated Hours</span>
+                <span className="font-headline text-lg font-medium text-primary">{project.estimatedHours}h</span>
+              </div>
+            )}
+            <div className="flex flex-col">
+              <span className="text-[10px] text-on-surface-variant uppercase tracking-widest mb-1">Views</span>
+              <span className="font-headline text-lg font-medium">{project.viewCount.toLocaleString()}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ================================================================
+          CONTENT GRID — Description (left) + Tech Stack Sidebar (right)
+          ================================================================ */}
+      <section className="max-w-7xl mx-auto px-8 mt-24 grid grid-cols-1 lg:grid-cols-12 gap-20">
+        {/* Description + Links */}
+        <div className="lg:col-span-7 space-y-12">
+          {project.fullDescription && (
+            <div className="space-y-6">
+              <h2 className="text-2xl font-bold text-on-surface border-l-2 border-primary pl-6 font-headline">
+                Mission Overview
+              </h2>
+              <div className="font-body text-lg leading-relaxed text-on-surface-variant space-y-6">
+                {project.fullDescription.split('\n\n').map((paragraph: string, i: number) => (
+                  <p key={i}>{paragraph}</p>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <ProjectLinks links={links} />
+        </div>
+
+        {/* Tech Stack Sidebar */}
+        {technologies.length > 0 && (
+          <div className="lg:col-span-5">
+            <div className="bg-surface-container-low p-10 rounded-xl border border-white/5">
+              <h2 className="text-xl font-bold mb-8 flex items-center gap-3 font-headline">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-primary">
+                  <polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" />
+                </svg>
+                Technology Stack
+              </h2>
+              <div className="flex flex-wrap gap-3">
+                {technologies.map((tech) => (
+                  <TechPill key={tech.id} name={tech.name} />
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* ================================================================
+          IMAGE GALLERY
+          ================================================================ */}
+      <ProjectGallery images={galleryImages} />
+
+      {/* Bottom spacing */}
+      <div className="h-32" />
+    </main>
   );
 }

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { usePageTitle } from '@/hooks';
 import { projectApi } from '@/api/projects';
 import { ProjectCard, LoadingSpinner, ErrorDisplay } from '@/components/ui';
-import type { ProjectResponse, TechnologyCategory } from '@/types';
+import type { ProjectResponse, TechnologyResponse, TechnologyCategory } from '@/types';
 
 /** Filter categories shown in the filter bar, mapped to TechnologyCategory values. */
 const CATEGORY_FILTERS: { label: string; value: TechnologyCategory | null }[] = [
@@ -59,9 +59,9 @@ export function ProjectsPage() {
   }, [fetchPage]);
 
   // ---- Derived: client-side category filter on loaded projects ----
-  const displayed = activeCategory
-    ? projects.filter((p) =>
-        (p.technologies ?? []).some((t) => t.category === activeCategory),
+  const displayed: ProjectResponse[] = activeCategory
+    ? projects.filter((p: ProjectResponse): boolean =>
+        (p.technologies ?? []).some((t: TechnologyResponse): boolean => t.category === activeCategory),
       )
     : projects;
 

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,6 @@
+/** Format an ISO date string to a readable format like "Feb 2024". */
+export function formatDate(dateStr: string | null): string | null {
+  if (!dateStr) return null;
+  const date = new Date(dateStr);
+  return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,1 @@
-// Utility functions will be exported from here
+export { formatDate } from './formatDate';


### PR DESCRIPTION
## Summary
- Build project detail page fetching by slug via `GET /projects/slug/{slug}`
- Hero image with gradient overlay, status/difficulty/type badges, metadata row (dates, hours, views)
- Full description, project links with type-specific icons, technology stack sidebar
- Adaptive image gallery (1/2/3+ image layouts with desaturated hover effect)
- Modularized into `ProjectLinks`, `ProjectGallery` components and `formatDate` utility
- Added explicit type annotations to ProjectsPage filter logic
- Added React hooks learning docs (useState, useEffect, useCallback)

## Test plan
- [ ] Navigate to a project from the projects listing page
- [ ] Verify hero image, badges, title, and metadata display correctly
- [ ] Verify project links open in new tabs
- [ ] Verify technology stack pills render
- [ ] Test with projects that have 0, 1, 2, 3+ images
- [ ] Test 404 handling with an invalid slug
- [ ] Verify back navigation returns to projects page

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)