### PR TITLE
feat: blog listing page with filters, search, and pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ design/stitch.zip
 *.njsproj
 *.sln
 *.sw?
+
+# Claude Code local config
+.claude/

--- a/github_issues/issues.md
+++ b/github_issues/issues.md
@@ -212,12 +212,12 @@ Build the individual project detail page.
 
 ---
 
-## Issue #8: Blog listing and blog post detail pages
+## Issue #8: Blog listing page with filtering and search
 
 **Labels:** `feature`
 
 **Description:**
-Build the blog listing page with category/tag filtering and the individual post detail page.
+Build the blog listing page with paginated posts, category/tag filters, and keyword search. Cards link to the detail page (built in Issue #9).
 
 **Tasks:**
 - [ ] Blog listing page calling `GET /api/v1/blog/posts/published/paginated`
@@ -226,23 +226,51 @@ Build the blog listing page with category/tag filtering and the individual post 
 - [ ] Filter by category: `GET /api/v1/blog/posts/category/:slug`
 - [ ] Filter by tag: `GET /api/v1/blog/posts/tag/:slug`
 - [ ] Search: `GET /api/v1/blog/posts/search?q=`
-- [ ] Blog post detail page by slug: `GET /api/v1/blog/posts/slug/:slug`
-- [ ] Markdown content rendering (install `react-markdown` + `react-syntax-highlighter`)
-- [ ] Post metadata: date, category, tags, reading time
-- [ ] Related posts section
-- [ ] Pagination on listing page
+- [ ] Pagination (Load More or numbered pages, matching Projects page pattern)
+- [ ] Card click navigates to `/blog/:slug`
+- [ ] Loading and empty states
+- [ ] Responsive layout matching Stitch mockup
 
-**Branch:** `feature/blog`
+**Branch:** `feature/blog-listing`
 
 **Acceptance Criteria:**
 - Published blog posts display with pagination
 - Category and tag filtering works
-- Individual posts render markdown with code syntax highlighting
 - Search filters posts by keyword
+- Clicking a card navigates to `/blog/:slug` (may 404 until #9 lands)
 
 ---
 
-## Issue #9: Certifications page
+## Issue #9: Blog post detail page with markdown rendering
+
+**Labels:** `feature`
+
+**Description:**
+Build the individual blog post detail page, including markdown content rendering with code syntax highlighting.
+
+**Tasks:**
+- [ ] Install dependencies: `react-markdown`, `react-syntax-highlighter`, `remark-gfm`
+- [ ] Fetch post by slug: `GET /api/v1/blog/posts/slug/:slug` (backend increments views)
+- [ ] Render markdown content with GitHub-flavored markdown (tables, strikethrough, task lists)
+- [ ] Syntax-highlighted code blocks matching the dark editorial theme
+- [ ] Post metadata: published date, reading time, category badges, tag pills
+- [ ] Featured image (primary blog post image) as hero
+- [ ] Related posts section (same category or shared tags)
+- [ ] 404 handling for invalid slugs
+- [ ] Back to blog navigation
+
+**Branch:** `feature/blog-detail`
+
+**Acceptance Criteria:**
+- Page loads correct post by URL slug
+- Markdown renders cleanly with headings, lists, links, images
+- Code blocks have syntax highlighting matching the dark theme
+- Metadata and related posts display correctly
+- Invalid slug shows 404 state
+
+---
+
+## Issue #10: Certifications page
 
 **Labels:** `feature`
 
@@ -267,7 +295,7 @@ Build the certifications showcase page with status filtering.
 
 ---
 
-## Issue #10: Contact page with form submission
+## Issue #11: Contact page with form submission
 
 **Labels:** `feature`
 
@@ -295,7 +323,7 @@ Build the contact page with a working form that submits to the backend.
 
 ---
 
-## Issue #11: Resume download integration
+## Issue #12: Resume download integration
 
 **Labels:** `feature`
 
@@ -317,7 +345,7 @@ Integrate resume download functionality.
 
 ---
 
-## Issue #12: SEO, meta tags, and performance optimization
+## Issue #13: SEO, meta tags, and performance optimization
 
 **Labels:** `enhancement`
 
@@ -343,7 +371,7 @@ Add SEO fundamentals, proper meta tags, Open Graph data, and performance optimiz
 
 ---
 
-## Issue #13: Deployment setup — Docker, Nginx, CI/CD
+## Issue #14: Deployment setup — Docker, Nginx, CI/CD
 
 **Labels:** `setup`, `enhancement`
 

--- a/src/components/ui/CategoryTab.tsx
+++ b/src/components/ui/CategoryTab.tsx
@@ -1,0 +1,24 @@
+interface CategoryTabProps {
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+}
+
+/**
+ * Primary filter pill — larger, rounded, used as a tab-like category selector.
+ * Active state uses the primary accent. Pair with TagChip for two-tier filter bars.
+ */
+export function CategoryTab({ label, isActive, onClick }: CategoryTabProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-5 py-2 rounded-full font-label text-sm font-semibold transition-all ${
+        isActive
+          ? 'bg-primary text-on-primary'
+          : 'bg-surface-variant text-on-surface-variant hover:text-on-surface hover:bg-surface-container-highest'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -1,0 +1,66 @@
+interface PaginationProps {
+  /** Current page index — zero-indexed to match the backend Spring Page response. */
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  /** Accessible label for the <nav>. Defaults to "Pagination". */
+  ariaLabel?: string;
+}
+
+export function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+  ariaLabel = 'Pagination',
+}: PaginationProps) {
+  const pages = Array.from({ length: totalPages }, (_, i) => i);
+  const prevDisabled = currentPage === 0;
+  const nextDisabled = currentPage >= totalPages - 1;
+
+  const baseBtn =
+    'min-w-[40px] h-10 px-3 rounded-md font-label text-sm font-semibold transition-all flex items-center justify-center';
+  const inactive =
+    'bg-surface-variant text-on-surface-variant hover:text-on-surface hover:bg-surface-container-highest';
+  const active = 'bg-primary text-on-primary';
+  const disabled = 'opacity-40 cursor-not-allowed';
+
+  return (
+    <nav
+      aria-label={ariaLabel}
+      className="mt-16 flex items-center justify-center gap-2 flex-wrap"
+    >
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={prevDisabled}
+        className={`${baseBtn} ${inactive} ${prevDisabled ? disabled : ''}`}
+        aria-label="Previous page"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="15 18 9 12 15 6" />
+        </svg>
+      </button>
+
+      {pages.map((p) => (
+        <button
+          key={p}
+          onClick={() => onPageChange(p)}
+          aria-current={p === currentPage ? 'page' : undefined}
+          className={`${baseBtn} ${p === currentPage ? active : inactive}`}
+        >
+          {p + 1}
+        </button>
+      ))}
+
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={nextDisabled}
+        className={`${baseBtn} ${inactive} ${nextDisabled ? disabled : ''}`}
+        aria-label="Next page"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </button>
+    </nav>
+  );
+}

--- a/src/components/ui/SearchInput.tsx
+++ b/src/components/ui/SearchInput.tsx
@@ -1,0 +1,61 @@
+interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onClear?: () => void;
+  placeholder?: string;
+  ariaLabel?: string;
+}
+
+/**
+ * Text input styled for the Casey Quinn. design system: input-well background,
+ * ghost border, focus ring in primary. Shows a clear button when non-empty.
+ * The consumer is expected to debounce the onChange value before firing API calls.
+ */
+export function SearchInput({
+  value,
+  onChange,
+  onClear,
+  placeholder = 'Search...',
+  ariaLabel = 'Search',
+}: SearchInputProps) {
+  const handleClear = () => {
+    onChange('');
+    onClear?.();
+  };
+
+  return (
+    <div className="relative w-full max-w-xl">
+      {/* Search icon */}
+      <div className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-on-surface-variant">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+      </div>
+
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        className="w-full pl-12 pr-10 py-3 bg-surface-container-lowest text-on-surface placeholder:text-on-surface-variant/60 rounded-md font-body text-base outline-none ring-1 ring-outline-variant/20 focus:ring-2 focus:ring-primary transition-all"
+      />
+
+      {/* Clear button (shown when there's input) */}
+      {value && (
+        <button
+          type="button"
+          onClick={handleClear}
+          aria-label="Clear search"
+          className="absolute inset-y-0 right-3 flex items-center text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/TagChip.tsx
+++ b/src/components/ui/TagChip.tsx
@@ -1,0 +1,24 @@
+interface TagChipProps {
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+}
+
+/**
+ * Secondary filter chip — smaller, uppercase, used for quick-filter tag rows.
+ * Active state uses the tertiary (pink) accent for micro-moment emphasis.
+ */
+export function TagChip({ label, isActive, onClick }: TagChipProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-3 py-1 rounded-full font-label text-[10px] uppercase tracking-wider font-bold transition-all ${
+        isActive
+          ? 'bg-tertiary/20 text-tertiary'
+          : 'bg-surface-variant text-on-surface-variant hover:text-on-surface hover:bg-surface-container-highest'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -15,3 +15,4 @@ export { ErrorDisplay } from './ErrorDisplay';
 export { Pagination } from './Pagination';
 export { CategoryTab } from './CategoryTab';
 export { TagChip } from './TagChip';
+export { SearchInput } from './SearchInput';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -12,3 +12,6 @@ export { ProjectLinks } from './ProjectLinks';
 export { ProjectGallery } from './ProjectGallery';
 export { LoadingSpinner } from './LoadingSpinner';
 export { ErrorDisplay } from './ErrorDisplay';
+export { Pagination } from './Pagination';
+export { CategoryTab } from './CategoryTab';
+export { TagChip } from './TagChip';

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -8,6 +8,7 @@ import {
   Pagination,
   CategoryTab,
   TagChip,
+  SearchInput,
 } from '@/components/ui';
 import type {
   BlogPostResponse,
@@ -16,15 +17,23 @@ import type {
 } from '@/types';
 
 const PAGE_SIZE = 5;
+const SEARCH_DEBOUNCE_MS = 300;
 
 export function BlogPage() {
   usePageTitle('Blog');
 
   // ---- Filter state ----
-  // At most one of these is non-null at a time (one-filter-at-a-time rule).
+  // At most one of category/tag/search is "active" at a time (one-filter rule).
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [page, setPage] = useState(0);
+
+  // ---- Search state ----
+  // `searchInput` updates on every keystroke (live UI).
+  // `debouncedSearch` lags behind by SEARCH_DEBOUNCE_MS and is what the fetch
+  // effect reads — so we don't hit the API on every keystroke.
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
 
   // ---- Data state ----
   const [posts, setPosts] = useState<BlogPostResponse[]>([]);
@@ -38,6 +47,18 @@ export function BlogPage() {
   // ---- Filter-bar data (categories + popular tags) ----
   const [categories, setCategories] = useState<BlogCategoryResponse[]>([]);
   const [popularTags, setPopularTags] = useState<BlogTagResponse[]>([]);
+
+  // ---- Debounce searchInput → debouncedSearch ----
+  // Every keystroke schedules a setter 300ms out. The cleanup cancels the
+  // pending timer before it can fire, so only the LAST keystroke in a burst
+  // actually updates debouncedSearch (which is what the fetch depends on).
+  useEffect(() => {
+    const timerId = setTimeout(
+      () => setDebouncedSearch(searchInput.trim()),
+      SEARCH_DEBOUNCE_MS,
+    );
+    return () => clearTimeout(timerId);
+  }, [searchInput]);
 
   // Load categories + popular tags once on mount. Parallel via Promise.all.
   // Non-blocking: if they fail, the filter bar just hides — posts still load.
@@ -62,7 +83,16 @@ export function BlogPage() {
     setLoading(true);
     setError(null);
 
-    const request = activeCategory
+    // Branch priority: search > category > tag > paginated (default).
+    // Mutual exclusion is enforced in the click handlers, so at most one of
+    // debouncedSearch / activeCategory / activeTag is non-empty.
+    const request = debouncedSearch
+      ? blogApi.posts.search(debouncedSearch).then((list) => ({
+          content: list,
+          totalPages: 0,
+          pageNumber: 0,
+        }))
+      : activeCategory
       ? blogApi.posts.getByCategory(activeCategory).then((list) => ({
           content: list,
           totalPages: 0,
@@ -91,8 +121,10 @@ export function BlogPage() {
         if (cancelled) return;
         setPosts(result.content);
         setTotalPages(result.totalPages);
-        // Only update page when paginated (filters don't paginate)
-        if (!activeCategory && !activeTag) setPage(result.pageNumber);
+        // Only sync page when paginated (filters and search don't paginate).
+        if (!debouncedSearch && !activeCategory && !activeTag) {
+          setPage(result.pageNumber);
+        }
       })
       .catch(() => {
         if (cancelled) return;
@@ -107,12 +139,15 @@ export function BlogPage() {
     return () => {
       cancelled = true;
     };
-  }, [activeCategory, activeTag, page, retryNonce]);
+  }, [debouncedSearch, activeCategory, activeTag, page, retryNonce]);
 
   // ---- Filter click handlers ----
+  // Any filter action clears the others to keep the one-filter-at-a-time rule.
   const handleSelectCategory = (slug: string | null) => {
     setActiveCategory(slug);
     setActiveTag(null);
+    setSearchInput('');
+    setDebouncedSearch('');
     setPage(0);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
@@ -120,8 +155,21 @@ export function BlogPage() {
   const handleSelectTag = (slug: string) => {
     setActiveTag((current) => (current === slug ? null : slug));
     setActiveCategory(null);
+    setSearchInput('');
+    setDebouncedSearch('');
     setPage(0);
     window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handleSearchChange = (next: string) => {
+    setSearchInput(next);
+    // Clear category/tag the moment the user starts typing. debouncedSearch
+    // will update 300ms after they stop, which is what triggers the fetch.
+    if (next.length > 0) {
+      setActiveCategory(null);
+      setActiveTag(null);
+      setPage(0);
+    }
   };
 
   const handlePageChange = (next: number) => {
@@ -129,7 +177,8 @@ export function BlogPage() {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
-  const hasActiveFilter = activeCategory !== null || activeTag !== null;
+  const hasActiveFilter =
+    activeCategory !== null || activeTag !== null || debouncedSearch.length > 0;
 
   return (
     <main className="pt-16 pb-24 px-6 md:px-12 max-w-7xl mx-auto">
@@ -146,10 +195,19 @@ export function BlogPage() {
       </header>
 
       {/* ==============================================================
-          FILTER BAR — categories (primary) + popular tags (secondary)
+          FILTER BAR — search + categories (primary) + popular tags (secondary)
           ============================================================== */}
-      {(categories.length > 0 || popularTags.length > 0) && (
-        <section className="mb-12 space-y-6">
+      <section className="mb-12 space-y-6">
+        {/* Search input */}
+        <SearchInput
+          value={searchInput}
+          onChange={handleSearchChange}
+          placeholder="Search posts by title, content, or excerpt..."
+          ariaLabel="Search blog posts"
+        />
+
+        {(categories.length > 0 || popularTags.length > 0) && (
+          <>
           {/* Category tabs */}
           {categories.length > 0 && (
             <div className="flex flex-wrap items-center gap-3">
@@ -185,8 +243,9 @@ export function BlogPage() {
               ))}
             </div>
           )}
-        </section>
-      )}
+          </>
+        )}
+      </section>
 
       {/* ==============================================================
           POST LIST
@@ -197,7 +256,9 @@ export function BlogPage() {
         <>
           {posts.length === 0 ? (
             <p className="text-on-surface-variant text-center py-16 text-lg">
-              {hasActiveFilter
+              {debouncedSearch
+                ? `No posts match "${debouncedSearch}".`
+                : hasActiveFilter
                 ? 'No posts match this filter.'
                 : 'No posts published yet.'}
             </p>

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -1,16 +1,156 @@
+import { useState, useEffect, useCallback } from 'react';
 import { usePageTitle } from '@/hooks';
+import { blogApi } from '@/api/blog';
+import { BlogPostCard, LoadingSpinner, ErrorDisplay } from '@/components/ui';
+import type { BlogPostResponse } from '@/types';
+
+const PAGE_SIZE = 5;
 
 export function BlogPage() {
   usePageTitle('Blog');
 
+  // ---- Data state ----
+  const [posts, setPosts] = useState<BlogPostResponse[]>([]);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // ---- Fetch a page of published posts ----
+  const fetchPage = useCallback((pageNum: number) => {
+    setLoading(true);
+    setError(null);
+
+    blogApi.posts
+      .getPublishedPaginated({ page: pageNum, size: PAGE_SIZE, sort: 'publishedAt,desc' })
+      .then((data) => {
+        setPosts(data.content);
+        setPage(data.page.number);
+        setTotalPages(data.page.totalPages);
+      })
+      .catch(() => setError('Failed to load blog posts.'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // ---- Initial fetch ----
+  useEffect(() => {
+    fetchPage(0);
+  }, [fetchPage]);
+
+  // ---- Change page and scroll to top of list ----
+  const handlePageChange = (next: number) => {
+    fetchPage(next);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
   return (
-    <div className="mx-auto max-w-7xl px-6 py-16">
-      <h1 className="font-headline text-5xl font-bold text-on-surface tracking-tight">
-        Blog
-      </h1>
-      <p className="mt-4 text-lg text-on-surface-variant">
-        Blog listing coming in Issue #8.
-      </p>
-    </div>
+    <main className="pt-16 pb-24 px-6 md:px-12 max-w-7xl mx-auto">
+      {/* ==============================================================
+          HERO HEADER
+          ============================================================== */}
+      <header className="mb-16 md:ml-[10%]">
+        <h1 className="font-headline text-5xl md:text-7xl font-bold tracking-tighter text-on-surface mb-4">
+          Blog<span className="text-primary">.</span>
+        </h1>
+        <p className="font-body text-on-surface-variant text-lg max-w-2xl leading-relaxed">
+          Notes, walkthroughs, and engineering decisions from the projects I ship.
+        </p>
+      </header>
+
+      {/* ==============================================================
+          POST LIST
+          ============================================================== */}
+      {loading && <LoadingSpinner message="Loading posts..." />}
+      {error && <ErrorDisplay message={error} onRetry={() => fetchPage(0)} />}
+      {!loading && !error && (
+        <>
+          {posts.length === 0 ? (
+            <p className="text-on-surface-variant text-center py-16 text-lg">
+              No posts published yet.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-6">
+              {posts.map((post) => (
+                <BlogPostCard key={post.id} post={post} />
+              ))}
+            </div>
+          )}
+
+          {/* ==============================================================
+              PAGINATION
+              ============================================================== */}
+          {totalPages > 1 && (
+            <Pagination
+              currentPage={page}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+            />
+          )}
+        </>
+      )}
+    </main>
+  );
+}
+
+// ============================================================================
+// Pagination — inline for now. Extract to components/ui if reused elsewhere.
+// ============================================================================
+
+interface PaginationProps {
+  currentPage: number;     // zero-indexed (matches backend)
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
+  const pages = Array.from({ length: totalPages }, (_, i) => i);
+  const prevDisabled = currentPage === 0;
+  const nextDisabled = currentPage >= totalPages - 1;
+
+  const baseBtn =
+    'min-w-[40px] h-10 px-3 rounded-md font-label text-sm font-semibold transition-all flex items-center justify-center';
+  const inactive =
+    'bg-surface-variant text-on-surface-variant hover:text-on-surface hover:bg-surface-container-highest';
+  const active = 'bg-primary text-on-primary';
+  const disabled = 'opacity-40 cursor-not-allowed';
+
+  return (
+    <nav
+      aria-label="Blog pagination"
+      className="mt-16 flex items-center justify-center gap-2 flex-wrap"
+    >
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={prevDisabled}
+        className={`${baseBtn} ${inactive} ${prevDisabled ? disabled : ''}`}
+        aria-label="Previous page"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="15 18 9 12 15 6" />
+        </svg>
+      </button>
+
+      {pages.map((p) => (
+        <button
+          key={p}
+          onClick={() => onPageChange(p)}
+          aria-current={p === currentPage ? 'page' : undefined}
+          className={`${baseBtn} ${p === currentPage ? active : inactive}`}
+        >
+          {p + 1}
+        </button>
+      ))}
+
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={nextDisabled}
+        className={`${baseBtn} ${inactive} ${nextDisabled ? disabled : ''}`}
+        aria-label="Next page"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </button>
+    </nav>
   );
 }

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -1,54 +1,142 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { usePageTitle } from '@/hooks';
 import { blogApi } from '@/api/blog';
-import { BlogPostCard, LoadingSpinner, ErrorDisplay } from '@/components/ui';
-import type { BlogPostResponse } from '@/types';
+import {
+  BlogPostCard,
+  LoadingSpinner,
+  ErrorDisplay,
+  Pagination,
+  CategoryTab,
+  TagChip,
+} from '@/components/ui';
+import type {
+  BlogPostResponse,
+  BlogCategoryResponse,
+  BlogTagResponse,
+} from '@/types';
 
 const PAGE_SIZE = 5;
 
 export function BlogPage() {
   usePageTitle('Blog');
 
+  // ---- Filter state ----
+  // At most one of these is non-null at a time (one-filter-at-a-time rule).
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+  const [page, setPage] = useState(0);
+
   // ---- Data state ----
   const [posts, setPosts] = useState<BlogPostResponse[]>([]);
-  const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Nonce bumped by the retry button — the fetch effect depends on it, so
+  // changing it re-runs the effect even when no filter/page state changed.
+  const [retryNonce, setRetryNonce] = useState(0);
 
-  // ---- Fetch a page of published posts ----
-  const fetchPage = useCallback((pageNum: number) => {
+  // ---- Filter-bar data (categories + popular tags) ----
+  const [categories, setCategories] = useState<BlogCategoryResponse[]>([]);
+  const [popularTags, setPopularTags] = useState<BlogTagResponse[]>([]);
+
+  // Load categories + popular tags once on mount. Parallel via Promise.all.
+  // Non-blocking: if they fail, the filter bar just hides — posts still load.
+  useEffect(() => {
+    Promise.all([blogApi.categories.getAll(), blogApi.tags.getPopular()])
+      .then(([cats, tags]) => {
+        setCategories(cats);
+        setPopularTags(tags);
+      })
+      .catch(() => {
+        /* filter bar stays empty */
+      });
+  }, []);
+
+  // ---- Main post fetch: re-runs when filters or page change ----
+  // The `cancelled` flag is our stale-response guard. If this effect re-runs
+  // before the in-flight request resolves (e.g. user clicks filter B while
+  // filter A's request is still loading), the cleanup below flips the flag
+  // and the stale .then() becomes a no-op.
+  useEffect(() => {
+    let cancelled = false;
     setLoading(true);
     setError(null);
 
-    blogApi.posts
-      .getPublishedPaginated({ page: pageNum, size: PAGE_SIZE, sort: 'publishedAt,desc' })
-      .then((data) => {
-        setPosts(data.content);
-        setPage(data.page.number);
-        setTotalPages(data.page.totalPages);
+    const request = activeCategory
+      ? blogApi.posts.getByCategory(activeCategory).then((list) => ({
+          content: list,
+          totalPages: 0,
+          pageNumber: 0,
+        }))
+      : activeTag
+      ? blogApi.posts.getByTag(activeTag).then((list) => ({
+          content: list,
+          totalPages: 0,
+          pageNumber: 0,
+        }))
+      : blogApi.posts
+          .getPublishedPaginated({
+            page,
+            size: PAGE_SIZE,
+            sort: 'publishedAt,desc',
+          })
+          .then((pageData) => ({
+            content: pageData.content,
+            totalPages: pageData.page.totalPages,
+            pageNumber: pageData.page.number,
+          }));
+
+    request
+      .then((result) => {
+        if (cancelled) return;
+        setPosts(result.content);
+        setTotalPages(result.totalPages);
+        // Only update page when paginated (filters don't paginate)
+        if (!activeCategory && !activeTag) setPage(result.pageNumber);
       })
-      .catch(() => setError('Failed to load blog posts.'))
-      .finally(() => setLoading(false));
-  }, []);
+      .catch(() => {
+        if (cancelled) return;
+        setError('Failed to load blog posts.');
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
 
-  // ---- Initial fetch ----
-  useEffect(() => {
-    fetchPage(0);
-  }, [fetchPage]);
+    // Cleanup runs before next effect execution, or on unmount.
+    return () => {
+      cancelled = true;
+    };
+  }, [activeCategory, activeTag, page, retryNonce]);
 
-  // ---- Change page and scroll to top of list ----
-  const handlePageChange = (next: number) => {
-    fetchPage(next);
+  // ---- Filter click handlers ----
+  const handleSelectCategory = (slug: string | null) => {
+    setActiveCategory(slug);
+    setActiveTag(null);
+    setPage(0);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
+
+  const handleSelectTag = (slug: string) => {
+    setActiveTag((current) => (current === slug ? null : slug));
+    setActiveCategory(null);
+    setPage(0);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handlePageChange = (next: number) => {
+    setPage(next);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const hasActiveFilter = activeCategory !== null || activeTag !== null;
 
   return (
     <main className="pt-16 pb-24 px-6 md:px-12 max-w-7xl mx-auto">
       {/* ==============================================================
           HERO HEADER
           ============================================================== */}
-      <header className="mb-16 md:ml-[10%]">
+      <header className="mb-12 md:ml-[10%]">
         <h1 className="font-headline text-5xl md:text-7xl font-bold tracking-tighter text-on-surface mb-4">
           Blog<span className="text-primary">.</span>
         </h1>
@@ -58,15 +146,60 @@ export function BlogPage() {
       </header>
 
       {/* ==============================================================
+          FILTER BAR — categories (primary) + popular tags (secondary)
+          ============================================================== */}
+      {(categories.length > 0 || popularTags.length > 0) && (
+        <section className="mb-12 space-y-6">
+          {/* Category tabs */}
+          {categories.length > 0 && (
+            <div className="flex flex-wrap items-center gap-3">
+              <CategoryTab
+                label="All Topics"
+                isActive={activeCategory === null && activeTag === null}
+                onClick={() => handleSelectCategory(null)}
+              />
+              {categories.map((cat) => (
+                <CategoryTab
+                  key={cat.id}
+                  label={cat.name}
+                  isActive={activeCategory === cat.slug}
+                  onClick={() => handleSelectCategory(cat.slug)}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Popular tag chips */}
+          {popularTags.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-label text-[10px] uppercase tracking-widest text-outline mr-2">
+                Quick filter:
+              </span>
+              {popularTags.map((tag) => (
+                <TagChip
+                  key={tag.id}
+                  label={tag.name}
+                  isActive={activeTag === tag.slug}
+                  onClick={() => handleSelectTag(tag.slug)}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      {/* ==============================================================
           POST LIST
           ============================================================== */}
       {loading && <LoadingSpinner message="Loading posts..." />}
-      {error && <ErrorDisplay message={error} onRetry={() => fetchPage(0)} />}
+      {error && <ErrorDisplay message={error} onRetry={() => setRetryNonce((n) => n + 1)} />}
       {!loading && !error && (
         <>
           {posts.length === 0 ? (
             <p className="text-on-surface-variant text-center py-16 text-lg">
-              No posts published yet.
+              {hasActiveFilter
+                ? 'No posts match this filter.'
+                : 'No posts published yet.'}
             </p>
           ) : (
             <div className="flex flex-col gap-6">
@@ -76,14 +209,13 @@ export function BlogPage() {
             </div>
           )}
 
-          {/* ==============================================================
-              PAGINATION
-              ============================================================== */}
-          {totalPages > 1 && (
+          {/* Pagination only when we're in unfiltered mode */}
+          {!hasActiveFilter && totalPages > 1 && (
             <Pagination
               currentPage={page}
               totalPages={totalPages}
               onPageChange={handlePageChange}
+              ariaLabel="Blog pagination"
             />
           )}
         </>
@@ -92,65 +224,3 @@ export function BlogPage() {
   );
 }
 
-// ============================================================================
-// Pagination — inline for now. Extract to components/ui if reused elsewhere.
-// ============================================================================
-
-interface PaginationProps {
-  currentPage: number;     // zero-indexed (matches backend)
-  totalPages: number;
-  onPageChange: (page: number) => void;
-}
-
-function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
-  const pages = Array.from({ length: totalPages }, (_, i) => i);
-  const prevDisabled = currentPage === 0;
-  const nextDisabled = currentPage >= totalPages - 1;
-
-  const baseBtn =
-    'min-w-[40px] h-10 px-3 rounded-md font-label text-sm font-semibold transition-all flex items-center justify-center';
-  const inactive =
-    'bg-surface-variant text-on-surface-variant hover:text-on-surface hover:bg-surface-container-highest';
-  const active = 'bg-primary text-on-primary';
-  const disabled = 'opacity-40 cursor-not-allowed';
-
-  return (
-    <nav
-      aria-label="Blog pagination"
-      className="mt-16 flex items-center justify-center gap-2 flex-wrap"
-    >
-      <button
-        onClick={() => onPageChange(currentPage - 1)}
-        disabled={prevDisabled}
-        className={`${baseBtn} ${inactive} ${prevDisabled ? disabled : ''}`}
-        aria-label="Previous page"
-      >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <polyline points="15 18 9 12 15 6" />
-        </svg>
-      </button>
-
-      {pages.map((p) => (
-        <button
-          key={p}
-          onClick={() => onPageChange(p)}
-          aria-current={p === currentPage ? 'page' : undefined}
-          className={`${baseBtn} ${p === currentPage ? active : inactive}`}
-        >
-          {p + 1}
-        </button>
-      ))}
-
-      <button
-        onClick={() => onPageChange(currentPage + 1)}
-        disabled={nextDisabled}
-        className={`${baseBtn} ${inactive} ${nextDisabled ? disabled : ''}`}
-        aria-label="Next page"
-      >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <polyline points="9 18 15 12 9 6" />
-        </svg>
-      </button>
-    </nav>
-  );
-}

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -19,6 +19,55 @@ import type {
 const PAGE_SIZE = 5;
 const SEARCH_DEBOUNCE_MS = 300;
 
+// Normalized shape we pass to the page regardless of which endpoint was hit.
+// List endpoints (search/category/tag) return no pagination info, so
+// totalPages/pageNumber are 0 — the page hides the pager in those modes.
+interface BlogFetchResult {
+  content: BlogPostResponse[];
+  totalPages: number;
+  pageNumber: number;
+}
+
+interface BlogFetchParams {
+  search: string;
+  category: string | null;
+  tag: string | null;
+  page: number;
+}
+
+function wrapList(list: BlogPostResponse[]): BlogFetchResult {
+  return { content: list, totalPages: 0, pageNumber: 0 };
+}
+
+/**
+ * Picks the right blog endpoint based on active filter state.
+ * Priority: search > category > tag > paginated (default). Mutual exclusion
+ * is enforced by the page's click handlers, so at most one is non-empty.
+ */
+function fetchBlogPosts({
+  search,
+  category,
+  tag,
+  page,
+}: BlogFetchParams): Promise<BlogFetchResult> {
+  if (search) {
+    return blogApi.posts.search(search).then(wrapList);
+  }
+  if (category) {
+    return blogApi.posts.getByCategory(category).then(wrapList);
+  }
+  if (tag) {
+    return blogApi.posts.getByTag(tag).then(wrapList);
+  }
+  return blogApi.posts
+    .getPublishedPaginated({ page, size: PAGE_SIZE, sort: 'publishedAt,desc' })
+    .then((pageData) => ({
+      content: pageData.content,
+      totalPages: pageData.page.totalPages,
+      pageNumber: pageData.page.number,
+    }));
+}
+
 export function BlogPage() {
   usePageTitle('Blog');
 
@@ -83,40 +132,12 @@ export function BlogPage() {
     setLoading(true);
     setError(null);
 
-    // Branch priority: search > category > tag > paginated (default).
-    // Mutual exclusion is enforced in the click handlers, so at most one of
-    // debouncedSearch / activeCategory / activeTag is non-empty.
-    const request = debouncedSearch
-      ? blogApi.posts.search(debouncedSearch).then((list) => ({
-          content: list,
-          totalPages: 0,
-          pageNumber: 0,
-        }))
-      : activeCategory
-      ? blogApi.posts.getByCategory(activeCategory).then((list) => ({
-          content: list,
-          totalPages: 0,
-          pageNumber: 0,
-        }))
-      : activeTag
-      ? blogApi.posts.getByTag(activeTag).then((list) => ({
-          content: list,
-          totalPages: 0,
-          pageNumber: 0,
-        }))
-      : blogApi.posts
-          .getPublishedPaginated({
-            page,
-            size: PAGE_SIZE,
-            sort: 'publishedAt,desc',
-          })
-          .then((pageData) => ({
-            content: pageData.content,
-            totalPages: pageData.page.totalPages,
-            pageNumber: pageData.page.number,
-          }));
-
-    request
+    fetchBlogPosts({
+      search: debouncedSearch,
+      category: activeCategory,
+      tag: activeTag,
+      page,
+    })
       .then((result) => {
         if (cancelled) return;
         setPosts(result.content);

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -16,8 +16,8 @@ import type {
   BlogTagResponse,
 } from '@/types';
 
-const PAGE_SIZE = 5;
-const SEARCH_DEBOUNCE_MS = 300;
+const PAGE_SIZE: number = 5;
+const SEARCH_DEBOUNCE_MS: number = 300;
 
 // Normalized shape we pass to the page regardless of which endpoint was hit.
 // List endpoints (search/category/tag) return no pagination info, so
@@ -44,28 +44,31 @@ function wrapList(list: BlogPostResponse[]): BlogFetchResult {
  * Priority: search > category > tag > paginated (default). Mutual exclusion
  * is enforced by the page's click handlers, so at most one is non-empty.
  */
-function fetchBlogPosts({
+async function fetchBlogPosts({
   search,
   category,
   tag,
   page,
 }: BlogFetchParams): Promise<BlogFetchResult> {
   if (search) {
-    return blogApi.posts.search(search).then(wrapList);
+    return wrapList(await blogApi.posts.search(search));
   }
   if (category) {
-    return blogApi.posts.getByCategory(category).then(wrapList);
+    return wrapList(await blogApi.posts.getByCategory(category));
   }
   if (tag) {
-    return blogApi.posts.getByTag(tag).then(wrapList);
+    return wrapList(await blogApi.posts.getByTag(tag));
   }
-  return blogApi.posts
-    .getPublishedPaginated({ page, size: PAGE_SIZE, sort: 'publishedAt,desc' })
-    .then((pageData) => ({
-      content: pageData.content,
-      totalPages: pageData.page.totalPages,
-      pageNumber: pageData.page.number,
-    }));
+  const pageData = await blogApi.posts.getPublishedPaginated({
+    page,
+    size: PAGE_SIZE,
+    sort: 'publishedAt,desc',
+  });
+  return {
+    content: pageData.content,
+    totalPages: pageData.page.totalPages,
+    pageNumber: pageData.page.number,
+  };
 }
 
 export function BlogPage() {


### PR DESCRIPTION
Closes #14.

## Summary
- Paginated blog listing at `/blog` using `GET /blog/posts/published/paginated`.
- Two-tier filter bar: category tabs (primary) and popular tag chips (secondary). One-filter-at-a-time rule enforced.
- Debounced keyword search (300ms) via `GET /blog/posts/search`.
- Numbered pagination (hidden when a filter or search is active — those endpoints return a full list, not a Page).
- Loading, error (with retry), and empty states.
- Splits issues.md #8 into listing (#8) + detail (#9).

## Architectural notes
- Stale-response guard on the main fetch `useEffect` — a local `cancelled` flag flipped in cleanup prevents late responses from rapid filter changes overwriting fresh state.
- Search uses two state vars: `searchInput` (live, drives UI) and `debouncedSearch` (lagged, drives fetch). Debounce via `setTimeout` + `clearTimeout` in a `useEffect`.
- Retry uses a `retryNonce` state that is only in the effect's deps so bumping it re-runs the fetch without touching other state.
- Extracted `Pagination`, `CategoryTab`, `TagChip`, `SearchInput` into `src/components/ui/` per the file-per-component convention.

## Test plan
- [ ] `/blog` renders paginated posts with images + metadata
- [ ] Clicking a category tab filters posts, clears any tag/search
- [ ] Clicking a tag chip filters posts, clears any category/search
- [ ] Typing in search fires exactly one API request per typing burst (verify in DevTools Network tab)
- [ ] `×` clear button on search returns to paginated view
- [ ] Pagination prev/next/numbered buttons all work
- [ ] Pagination hides when any filter or search is active
- [ ] Empty-state copy reflects the search query when no matches
- [ ] Loading, error (disconnect backend to verify), and retry states all render
- [ ] Responsive on mobile (single column, wrapping filter pills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)