### PR TITLE
enhancement: full-width blog article with related posts as footer section

### DIFF
--- a/src/components/ui/RelatedPosts.tsx
+++ b/src/components/ui/RelatedPosts.tsx
@@ -10,40 +10,42 @@ export function RelatedPosts({ posts }: RelatedPostsProps) {
 
   return (
     <section aria-labelledby="related-posts-heading">
-      <h3
+      <h2
         id="related-posts-heading"
-        className="font-headline text-xl font-bold mb-6 flex items-center gap-2"
+        className="font-headline text-2xl md:text-3xl font-bold mb-8 flex items-center gap-3 tracking-tight"
       >
-        <span className="w-1 h-6 bg-primary" aria-hidden="true" />
+        <span className="w-1.5 h-8 bg-primary" aria-hidden="true" />
         Related Posts
-      </h3>
-      <div className="space-y-6">
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {posts.map((post) => {
           const category = (post.categories ?? [])[0];
           return (
             <article
               key={post.id}
-              className="group bg-surface-container p-5 rounded-xl hover:bg-surface-container-highest transition-colors"
+              className="group relative bg-surface-container p-6 rounded-xl hover:bg-surface-container-highest transition-colors"
             >
               {category && (
                 <span className="text-[10px] font-bold text-tertiary-dim uppercase tracking-tighter">
                   {category.name}
                 </span>
               )}
-              <h4 className="font-headline font-semibold text-lg mt-2 text-on-surface group-hover:text-primary transition-colors">
-                <Link to={`/blog/${post.slug}`}>{post.title}</Link>
-              </h4>
+              <h3 className="font-headline font-semibold text-lg mt-2 text-on-surface group-hover:text-primary transition-colors">
+                <Link
+                  to={`/blog/${post.slug}`}
+                  className="before:absolute before:inset-0 before:content-['']"
+                >
+                  {post.title}
+                </Link>
+              </h3>
               {post.excerpt && (
-                <p className="text-sm text-on-surface-variant mt-2 line-clamp-2">
+                <p className="text-sm text-on-surface-variant mt-2 line-clamp-3">
                   {post.excerpt}
                 </p>
               )}
-              <Link
-                to={`/blog/${post.slug}`}
-                className="inline-block mt-4 text-xs font-bold text-primary group-hover:underline"
-              >
-                Read Article
-              </Link>
+              <span className="inline-block mt-4 text-xs font-bold text-primary group-hover:underline">
+                Read Article →
+              </span>
             </article>
           );
         })}

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -7,7 +7,6 @@ import {
   ErrorDisplay,
   MarkdownRenderer,
   RelatedPosts,
-  NewsletterCard,
 } from '@/components/ui';
 import type { BlogPostResponse } from '@/types';
 
@@ -158,80 +157,79 @@ export function BlogPostPage() {
       )}
 
       <article
-        className={`max-w-7xl mx-auto px-6 grid grid-cols-1 lg:grid-cols-12 gap-12 lg:gap-16 relative z-10 ${
+        className={`max-w-4xl mx-auto px-6 relative z-10 ${
           heroImage ? '-mt-24 md:-mt-32' : 'mt-8'
         }`}
       >
-        <div className="lg:col-span-8">
-          <div className="bg-surface-container-low p-6 md:p-10 lg:p-12 rounded-xl">
-            <header className="mb-10">
-              {primaryCategory && (
-                <span className="inline-block px-3 py-1 bg-surface-container-highest text-tertiary rounded-full text-xs font-bold tracking-widest mb-4 uppercase">
-                  {primaryCategory.name}
-                </span>
-              )}
-              <h1 className="text-3xl md:text-5xl lg:text-6xl font-headline font-bold text-on-background leading-tight tracking-tighter mb-8">
-                {post.title}
-              </h1>
-              <div className="flex flex-wrap items-center gap-y-4 gap-x-8 text-on-surface-variant font-medium text-sm py-6 border-y border-outline-variant/10">
-                <div className="flex items-center gap-2">
-                  <div className="w-8 h-8 rounded-full bg-primary-dim flex items-center justify-center text-[10px] text-on-primary font-bold">
-                    CQ
-                  </div>
-                  <span>Casey Quinn</span>
+        <div className="bg-surface-container-low p-6 md:p-10 lg:p-12 rounded-xl">
+          <header className="mb-10">
+            {primaryCategory && (
+              <span className="inline-block px-3 py-1 bg-surface-container-highest text-tertiary rounded-full text-xs font-bold tracking-widest mb-4 uppercase">
+                {primaryCategory.name}
+              </span>
+            )}
+            <h1 className="text-3xl md:text-5xl lg:text-6xl font-headline font-bold text-on-background leading-tight tracking-tighter mb-8">
+              {post.title}
+            </h1>
+            <div className="flex flex-wrap items-center gap-y-4 gap-x-8 text-on-surface-variant font-medium text-sm py-6 border-y border-outline-variant/10">
+              <div className="flex items-center gap-2">
+                <div className="w-8 h-8 rounded-full bg-primary-dim flex items-center justify-center text-[10px] text-on-primary font-bold">
+                  CQ
                 </div>
-                {publishDate && (
-                  <div className="flex items-center gap-2">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-                      <line x1="16" y1="2" x2="16" y2="6" />
-                      <line x1="8" y1="2" x2="8" y2="6" />
-                      <line x1="3" y1="10" x2="21" y2="10" />
-                    </svg>
-                    <span>{publishDate}</span>
-                  </div>
-                )}
-                {post.readTimeMinutes != null && (
-                  <div className="flex items-center gap-2">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <circle cx="12" cy="12" r="10" />
-                      <polyline points="12 6 12 12 16 14" />
-                    </svg>
-                    <span>{post.readTimeMinutes} min read</span>
-                  </div>
-                )}
+                <span>Casey Quinn</span>
+              </div>
+              {publishDate && (
                 <div className="flex items-center gap-2">
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                    <circle cx="12" cy="12" r="3" />
+                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                    <line x1="16" y1="2" x2="16" y2="6" />
+                    <line x1="8" y1="2" x2="8" y2="6" />
+                    <line x1="3" y1="10" x2="21" y2="10" />
                   </svg>
-                  <span>{post.viewCount.toLocaleString()} views</span>
+                  <span>{publishDate}</span>
                 </div>
+              )}
+              {post.readTimeMinutes != null && (
+                <div className="flex items-center gap-2">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="10" />
+                    <polyline points="12 6 12 12 16 14" />
+                  </svg>
+                  <span>{post.readTimeMinutes} min read</span>
+                </div>
+              )}
+              <div className="flex items-center gap-2">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+                <span>{post.viewCount.toLocaleString()} views</span>
               </div>
-            </header>
+            </div>
+          </header>
 
-            <MarkdownRenderer content={post.content} />
+          <MarkdownRenderer content={post.content} />
 
-            {tags.length > 0 && (
-              <div className="mt-12 pt-8 border-t border-outline-variant/10 flex flex-wrap gap-3">
-                {tags.map((tag) => (
-                  <span
-                    key={tag.id}
-                    className="px-3 py-1 bg-surface-container text-on-surface-variant rounded-full text-xs font-mono"
-                  >
-                    #{tag.name}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
+          {tags.length > 0 && (
+            <div className="mt-12 pt-8 border-t border-outline-variant/10 flex flex-wrap gap-3">
+              {tags.map((tag) => (
+                <span
+                  key={tag.id}
+                  className="px-3 py-1 bg-surface-container text-on-surface-variant rounded-full text-xs font-mono"
+                >
+                  #{tag.name}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
-
-        <aside className="lg:col-span-4 space-y-10">
-          <RelatedPosts posts={related} />
-          <NewsletterCard />
-        </aside>
       </article>
+
+      {related.length > 0 && (
+        <section className="max-w-7xl mx-auto px-6 mt-24">
+          <RelatedPosts posts={related} />
+        </section>
+      )}
 
       <div className="h-24" />
     </main>


### PR DESCRIPTION
Small layout iteration on the blog post detail page. Design spec has the article + related posts side-by-side in a 12-col grid; in practice that pinches code blocks and makes long-form reading feel cramped on desktop. Most technical blogs (Stripe, Vercel, Netlify) use a single focused article column with related content as a "what to read next" footer — this matches that pattern.

## Changes
- `BlogPostPage.tsx`: article wrapper dropped from `max-w-7xl + 12-col grid` to `max-w-4xl` single column (~900px, comfortable reading + room for code blocks).
- `RelatedPosts` moved out of a sidebar `<aside>` into its own `<section className="max-w-7xl mt-24">` below the article.
- `NewsletterCard` removed from this page for now. Component file and export are kept — will be reintroduced when the newsletter backend endpoint lands.
- `RelatedPosts`: vertical stack → responsive grid (1/2/3 col at sm/md/lg). Heading promoted from `h3` text-xl to `h2` text-2xl/3xl since it's now a page-level section header. Cards get the stretched-link pattern (whole card clickable), and the redundant inner anchor is swapped for a span to avoid nesting `<a>` inside a stretched link.

Design doc is a guide — this deviates intentionally.

## Test plan
- [ ] Desktop: article column is noticeably wider, related posts appear as a 3-col row below
- [ ] Tablet (md): related posts render as a 2-col grid
- [ ] Mobile (sm): article full width, related posts single column stacked below
- [ ] Clicking any spot on a related-post card navigates to that post
- [ ] Hero image + article overlap (`-mt-24/-mt-32`) still looks right
- [ ] No newsletter card visible on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)