### PR TITLE
feat(certifications): status-filtered showcase page (issue #10)

### DIFF
--- a/src/components/ui/CertificationCard.tsx
+++ b/src/components/ui/CertificationCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { CertificationResponse } from '@/types';
 import { TechPill } from './TechPill';
 import { CertificationStatusBadge } from './CertificationStatusBadge';
@@ -8,6 +9,14 @@ interface CertificationCardProps {
 }
 
 export function CertificationCard({ certification, featured = false }: CertificationCardProps) {
+  // Tracks whether the badgeUrl image failed to load (404, CORS, network, or
+  // a stale/placeholder URL). When true, we fall back to the star SVG so the
+  // featured card never renders a broken-image glyph. Reset naturally on
+  // remount — the parent keys each card by cert.id, so swapping certs
+  // creates a fresh instance with badgeFailed=false.
+  const [badgeFailed, setBadgeFailed] = useState(false);
+  const showBadgeImage = featured && certification.badgeUrl && !badgeFailed;
+
   const issueDate = certification.issueDate
     ? new Date(certification.issueDate + 'T00:00:00').toLocaleDateString('en-US', { year: 'numeric', month: 'short' })
     : null;
@@ -33,10 +42,11 @@ export function CertificationCard({ certification, featured = false }: Certifica
               star icon when badgeUrl is null. Opacity stays low so it reads
               as atmosphere, not branding. */}
           <div className="absolute top-0 right-0 p-8 opacity-10 group-hover:opacity-20 transition-opacity pointer-events-none">
-            {certification.badgeUrl ? (
+            {showBadgeImage ? (
               <img
-                src={certification.badgeUrl}
+                src={certification.badgeUrl!}
                 alt=""
+                onError={() => setBadgeFailed(true)}
                 className="w-32 h-32 object-contain"
               />
             ) : (

--- a/src/components/ui/CertificationCard.tsx
+++ b/src/components/ui/CertificationCard.tsx
@@ -4,28 +4,61 @@ import { CertificationStatusBadge } from './CertificationStatusBadge';
 
 interface CertificationCardProps {
   certification: CertificationResponse;
+  featured?: boolean;
 }
 
-export function CertificationCard({ certification }: CertificationCardProps) {
+export function CertificationCard({ certification, featured = false }: CertificationCardProps) {
   const issueDate = certification.issueDate
     ? new Date(certification.issueDate + 'T00:00:00').toLocaleDateString('en-US', { year: 'numeric', month: 'short' })
     : null;
 
+  const containerClasses = featured
+    ? 'group relative bg-surface-container-low p-10 rounded-xl transition-all duration-500 hover:bg-surface-container-high border border-primary/20 shadow-[0_0_40px_rgba(163,166,255,0.05)] overflow-hidden lg:col-span-2'
+    : 'group bg-surface-container-low p-10 rounded-xl transition-all duration-500 hover:bg-surface-container-high border border-outline-variant/10';
+
+  const titleClasses = featured
+    ? 'font-headline text-3xl font-bold mb-4 group-hover:text-primary transition-colors'
+    : 'font-headline text-xl font-bold mb-2 group-hover:text-primary transition-colors';
+
+  const descriptionClasses = featured
+    ? 'text-on-surface-variant mb-8 max-w-lg font-body leading-relaxed'
+    : 'text-on-surface-variant text-sm mb-8 leading-relaxed';
+
   return (
-    <div className="group bg-surface-container-low p-10 rounded-xl transition-all duration-500 hover:bg-surface-container-high border border-outline-variant/10">
-      <div className="flex flex-col h-full">
+    <div className={containerClasses}>
+      {featured && (
+        <>
+          {/* Decorative watermark — a large, low-opacity badge icon that
+              signals "this is the featured card" without pulling focus. */}
+          <div className="absolute top-0 right-0 p-8 opacity-10 group-hover:opacity-20 transition-opacity pointer-events-none">
+            <svg width="128" height="128" viewBox="0 0 24 24" fill="currentColor" className="text-primary">
+              <path d="M12 2l2.39 4.84 5.34.78-3.86 3.77.91 5.32L12 14.19l-4.78 2.52.91-5.32L4.27 7.62l5.34-.78L12 2z" />
+            </svg>
+          </div>
+        </>
+      )}
+
+      <div className="relative z-10 flex flex-col h-full">
         {/* Status + date row */}
-        <div className="flex items-center gap-3 mb-8">
-          <CertificationStatusBadge status={certification.status} />
-          {issueDate && (
-            <span className="text-on-surface-variant text-sm tracking-wide">
-              {issueDate}
-            </span>
+        <div className="flex justify-between items-start mb-8">
+          <div className="flex items-center gap-3">
+            <CertificationStatusBadge status={certification.status} />
+            {issueDate && (
+              <span className="text-on-surface-variant text-sm tracking-wide">
+                {featured ? `Issued: ${issueDate}` : issueDate}
+              </span>
+            )}
+          </div>
+          {featured && (
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-primary">
+              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+              <polyline points="22 4 12 14.01 9 11.01" />
+            </svg>
           )}
         </div>
 
         {/* Title */}
-        <h3 className="font-headline text-xl font-bold mb-2 group-hover:text-primary transition-colors">
+        <h3 className={titleClasses}>
           {certification.name}
         </h3>
 
@@ -36,7 +69,7 @@ export function CertificationCard({ certification }: CertificationCardProps) {
 
         {/* Description */}
         {certification.description && (
-          <p className="text-on-surface-variant text-sm mb-8 leading-relaxed">
+          <p className={descriptionClasses}>
             {certification.description}
           </p>
         )}
@@ -60,49 +93,56 @@ export function CertificationCard({ certification }: CertificationCardProps) {
  * PURPOSE:
  *   Card displaying a professional certification with status badge, issue
  *   date, organization name, description, and associated technologies.
- *   Used on the Certifications page.
+ *   Supports a `featured` variant that spans 2 grid columns, adds a primary
+ *   glow border, a verified checkmark, and a decorative watermark icon.
  *
  * PROPS:
  *   certification: CertificationResponse — full certification from the API
+ *   featured?: boolean — when true, render the hero "featured" variant
  *
  * REACT PATTERNS:
  *
+ *   Default parameter value in destructuring: `featured = false`
+ *     - Same as Java method overloading / default arguments. The caller can
+ *       omit `featured` entirely and the component defaults to the regular
+ *       card. Keeps every existing callsite working without a prop update.
+ *
+ *   Derived class strings via if-else
+ *     - Rather than building className with template literals and ternaries
+ *       inline in JSX (which gets hard to read), we compute the container /
+ *       title / description classes as named variables and slot them in.
+ *
  *   new Date(certification.issueDate + 'T00:00:00')
- *     - The backend returns date-only strings like "2023-10-15" (no time)
- *     - Appending 'T00:00:00' prevents timezone parsing issues where
+ *     - The backend returns date-only strings like "2023-10-15" (no time).
+ *       Appending 'T00:00:00' prevents timezone parsing issues where
  *       "2023-10-15" alone might be interpreted as UTC midnight and
- *       display as the previous day in western timezones
- *     - Java analogy: LocalDate vs LocalDateTime parsing differences
+ *       display as the previous day in western timezones.
+ *     - Java analogy: LocalDate vs LocalDateTime parsing differences.
  *
  *   mt-auto on the tech pills container
  *     - Pushes the tech pills to the bottom of the card regardless of
  *       how much content is above them. This ensures all cards in a grid
  *       have their tech pills aligned at the same vertical position.
- *     - Works because the parent has `flex flex-col h-full`
+ *     - Works because the parent has `flex flex-col h-full`.
  *
- * TAILWIND BREAKDOWN:
- *   Card: "group bg-surface-container-low p-10 rounded-xl transition-all duration-500
- *          hover:bg-surface-container-high border border-outline-variant/10"
+ * TAILWIND BREAKDOWN (featured variant additions):
  *   ┌─────────────────────────┬──────────────────────────────────┬──────────────────────────────────┐
  *   │ Tailwind                 │ CSS                              │ What it does                     │
  *   ├─────────────────────────┼──────────────────────────────────┼──────────────────────────────────┤
- *   │ bg-surface-container-    │ background: #131313              │ Dark card background             │
- *   │ low                      │                                  │                                  │
- *   │ p-10                     │ padding: 40px                    │ Generous padding (more than      │
- *   │                          │                                  │ project cards — spacious feel)   │
- *   │ hover:bg-surface-        │ :hover { background: #201f1f }  │ Tonal lift on hover              │
- *   │ container-high           │                                  │                                  │
- *   │ border                   │ border-width: 1px                │ Very subtle border               │
- *   │ border-outline-          │ border-color: rgba(73,72,71,     │ at 10% opacity — barely          │
- *   │ variant/10               │ 0.1)                             │ visible ghost border             │
- *   └─────────────────────────┴──────────────────────────────────┴──────────────────────────────────┘
- *
- *   Title hover: "group-hover:text-primary transition-colors"
- *   ┌─────────────────────────┬──────────────────────────────────┬──────────────────────────────────┐
- *   │ group-hover:text-primary │ .group:hover & { color:          │ Title turns indigo when the      │
- *   │                          │ #a3a6ff }                        │ CARD is hovered (not just the    │
- *   │                          │                                  │ title itself)                    │
- *   │ transition-colors        │ transition: color 150ms          │ Smooth color fade                │
+ *   │ lg:col-span-2            │ grid-column: span 2              │ At lg breakpoint, card           │
+ *   │                          │                                  │ spans 2 of the 3 grid columns    │
+ *   │ border-primary/20        │ border-color: rgba(163,166,255,  │ Indigo-tinted border —           │
+ *   │                          │ 0.2)                             │ signals "featured" subtly        │
+ *   │ shadow-[0_0_40px_rgba    │ box-shadow: 0 0 40px             │ Outer glow, very faint — the    │
+ *   │ (163,166,255,0.05)]      │ rgba(163,166,255,0.05)           │ "atmospheric" feel the design   │
+ *   │                          │                                  │ system calls for                │
+ *   │ overflow-hidden          │ overflow: hidden                 │ Clips the watermark icon so it   │
+ *   │                          │                                  │ doesn't leak outside the card    │
+ *   │ absolute top-0 right-0   │ position: absolute; top/right 0  │ Pins watermark to top-right     │
+ *   │ opacity-10 group-hover:  │ opacity transitions on card hvr  │ Watermark brightens when user   │
+ *   │ opacity-20               │                                  │ hovers the card                 │
+ *   │ pointer-events-none      │ pointer-events: none             │ Watermark never intercepts      │
+ *   │                          │                                  │ clicks — purely decorative       │
  *   └─────────────────────────┴──────────────────────────────────┴──────────────────────────────────┘
  *
  * ============================================================================

--- a/src/components/ui/CertificationCard.tsx
+++ b/src/components/ui/CertificationCard.tsx
@@ -28,12 +28,22 @@ export function CertificationCard({ certification, featured = false }: Certifica
     <div className={containerClasses}>
       {featured && (
         <>
-          {/* Decorative watermark — a large, low-opacity badge icon that
-              signals "this is the featured card" without pulling focus. */}
+          {/* Decorative watermark — prefer the cert's real badgeUrl (e.g. AWS
+              logo) so it feels tied to the credential; fall back to a generic
+              star icon when badgeUrl is null. Opacity stays low so it reads
+              as atmosphere, not branding. */}
           <div className="absolute top-0 right-0 p-8 opacity-10 group-hover:opacity-20 transition-opacity pointer-events-none">
-            <svg width="128" height="128" viewBox="0 0 24 24" fill="currentColor" className="text-primary">
-              <path d="M12 2l2.39 4.84 5.34.78-3.86 3.77.91 5.32L12 14.19l-4.78 2.52.91-5.32L4.27 7.62l5.34-.78L12 2z" />
-            </svg>
+            {certification.badgeUrl ? (
+              <img
+                src={certification.badgeUrl}
+                alt=""
+                className="w-32 h-32 object-contain"
+              />
+            ) : (
+              <svg width="128" height="128" viewBox="0 0 24 24" fill="currentColor" className="text-primary">
+                <path d="M12 2l2.39 4.84 5.34.78-3.86 3.77.91 5.32L12 14.19l-4.78 2.52.91-5.32L4.27 7.62l5.34-.78L12 2z" />
+              </svg>
+            )}
           </div>
         </>
       )}
@@ -80,6 +90,32 @@ export function CertificationCard({ certification, featured = false }: Certifica
             <TechPill key={tech.id} name={tech.name} />
           ))}
         </div>
+
+        {/* Verify row — external link to the credential + optional ID.
+            Renders only when credentialUrl is present. A thin divider
+            separates it from the tech pills above so the link reads as a
+            distinct action, not another pill. */}
+        {certification.credentialUrl && (
+          <div className="mt-4 pt-4 border-t border-outline-variant/15 flex flex-wrap items-center gap-x-4 gap-y-2">
+            <a
+              href={certification.credentialUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`Verify ${certification.name} credential`}
+              className="inline-flex items-center gap-1.5 text-[11px] font-label uppercase tracking-widest text-primary hover:text-on-surface transition-colors"
+            >
+              Verify
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M7 17L17 7M17 7H7M17 7v10" />
+              </svg>
+            </a>
+            {certification.credentialId && (
+              <span className="text-[11px] font-label uppercase tracking-widest text-outline">
+                ID: {certification.credentialId}
+              </span>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/CertificationsPage.tsx
+++ b/src/pages/CertificationsPage.tsx
@@ -1,16 +1,196 @@
+import { useState, useEffect } from 'react';
 import { usePageTitle } from '@/hooks';
+import { certificationApi } from '@/api/certifications';
+import { CertificationCard, LoadingSpinner, ErrorDisplay } from '@/components/ui';
+import type { CertificationResponse, CertificationStatus } from '@/types';
+
+/** Filter buttons shown above the grid. `null` means "All". */
+const STATUS_FILTERS: { label: string; value: CertificationStatus | null }[] = [
+  { label: 'All',         value: null },
+  { label: 'Earned',      value: 'EARNED' },
+  { label: 'In Progress', value: 'IN_PROGRESS' },
+];
+
+/**
+ * Sort order for the grid:
+ *   1. Featured certs first (the design shows a big hero card up top)
+ *   2. Then by displayOrder ascending (curated ordering from admin)
+ *   3. Finally by issueDate descending (most recent first) as a tiebreaker
+ */
+function sortForDisplay(list: CertificationResponse[]): CertificationResponse[] {
+  return [...list].sort((a, b) => {
+    if (a.featured !== b.featured) return a.featured ? -1 : 1;
+    if (a.displayOrder !== b.displayOrder) return a.displayOrder - b.displayOrder;
+    const aDate = a.issueDate ?? '';
+    const bDate = b.issueDate ?? '';
+    return bDate.localeCompare(aDate);
+  });
+}
 
 export function CertificationsPage() {
   usePageTitle('Certifications');
 
+  const [certifications, setCertifications] = useState<CertificationResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  const [activeStatus, setActiveStatus] = useState<CertificationStatus | null>(null);
+
+  // Fetch all published certs once. Status filtering happens client-side so
+  // clicking between tabs is instant and doesn't re-hit the API.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    certificationApi
+      .getPublished()
+      .then((data) => {
+        if (cancelled) return;
+        setCertifications(sortForDisplay(data));
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setError('Failed to load certifications.');
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [retryNonce]);
+
+  const displayed = activeStatus
+    ? certifications.filter((c) => c.status === activeStatus)
+    : certifications;
+
+  // Only the first featured cert in the CURRENT view renders as the big hero
+  // card. When the user filters to "In Progress", the featured hero may not
+  // appear — that's intended: it's a visual hierarchy tied to the list, not
+  // a permanent attribute of a specific cert.
+  const featuredId = displayed.find((c) => c.featured)?.id ?? null;
+
   return (
-    <div className="mx-auto max-w-7xl px-6 py-16">
-      <h1 className="font-headline text-5xl font-bold text-on-surface tracking-tight">
-        Certifications
-      </h1>
-      <p className="mt-4 text-lg text-on-surface-variant">
-        Certifications page coming in Issue #9.
-      </p>
-    </div>
+    <main className="pt-16 pb-24 px-6 md:px-12 max-w-7xl mx-auto">
+      {/* ==============================================================
+          HERO HEADER
+          ============================================================== */}
+      <header className="mb-12 md:ml-[10%]">
+        <h1 className="font-headline text-5xl md:text-7xl font-bold tracking-tighter text-on-surface mb-4">
+          Certifications<span className="text-primary">.</span>
+        </h1>
+        <p className="font-body text-on-surface-variant text-lg max-w-2xl leading-relaxed">
+          Validating technical expertise and continuous learning.
+        </p>
+      </header>
+
+      {/* ==============================================================
+          STATUS FILTER
+          ============================================================== */}
+      <section className="mb-12 flex flex-wrap items-center gap-3">
+        <span className="font-label text-xs uppercase tracking-widest text-outline mr-2">
+          Status:
+        </span>
+        {STATUS_FILTERS.map((filter) => {
+          const isActive = activeStatus === filter.value;
+          return (
+            <button
+              key={filter.label}
+              onClick={() => setActiveStatus(filter.value)}
+              className={`px-6 py-2 rounded-full font-label text-sm font-semibold transition-all ${
+                isActive
+                  ? 'bg-primary text-on-primary'
+                  : 'bg-surface-variant text-on-surface-variant hover:text-on-surface hover:bg-surface-container-highest'
+              }`}
+            >
+              {filter.label}
+            </button>
+          );
+        })}
+      </section>
+
+      {/* ==============================================================
+          CERT GRID
+          ============================================================== */}
+      {loading && <LoadingSpinner message="Loading certifications..." />}
+      {error && <ErrorDisplay message={error} onRetry={() => setRetryNonce((n) => n + 1)} />}
+      {!loading && !error && (
+        <>
+          {displayed.length === 0 ? (
+            <p className="text-on-surface-variant text-center py-16 text-lg">
+              {activeStatus
+                ? 'No certifications match this filter.'
+                : 'No certifications published yet.'}
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+              {displayed.map((cert) => (
+                <CertificationCard
+                  key={cert.id}
+                  certification={cert}
+                  featured={cert.id === featuredId}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </main>
   );
 }
+
+/*
+ * ============================================================================
+ * PAGE: CertificationsPage
+ * ============================================================================
+ *
+ * PURPOSE:
+ *   Certifications showcase at /certifications. Displays published certs in
+ *   a responsive grid with status filtering (All / Earned / In Progress).
+ *   The first featured cert in the current view spans 2 columns and gets
+ *   the "hero card" treatment.
+ *
+ * DATA STRATEGY:
+ *   Fetch GET /certifications/published once on mount, then filter client-
+ *   side. This keeps tab switching instant and avoids spamming the API.
+ *
+ * REACT PATTERNS:
+ *
+ *   1. CLIENT-SIDE FILTER
+ *      `displayed` is derived from `certifications` + `activeStatus` on each
+ *      render. No separate state for filtered data — it's a pure function
+ *      of the source list and the active filter. This avoids the classic
+ *      "two states out of sync" bug.
+ *
+ *      Java analogue: like calling list.stream().filter(...).toList()
+ *      every time you need the filtered view, rather than caching it.
+ *
+ *   2. STALE-RESPONSE GUARD (`cancelled` flag)
+ *      If the retry button is mashed, or the component unmounts before the
+ *      fetch resolves, the cleanup flips `cancelled = true` and the
+ *      handlers bail out — preventing a "setting state on an unmounted
+ *      component" warning and out-of-order state writes.
+ *
+ *   3. RETRY VIA NONCE BUMP
+ *      `retryNonce` is a counter the retry button increments. Because it's
+ *      in the effect's deps array, bumping it re-runs the effect. Retrying
+ *      doesn't touch filter state, so the user's tab selection survives.
+ *
+ *   4. SORT STABILITY
+ *      `sortForDisplay` uses [...list].sort(...) — the spread creates a
+ *      fresh array so we don't mutate the original. Array.prototype.sort is
+ *      in-place; without the copy we'd be mutating state directly, which
+ *      React wouldn't notice (same reference = no re-render triggered).
+ *
+ *   5. DYNAMIC FEATURED SELECTION
+ *      `featuredId` is picked from the CURRENT `displayed` list, not the
+ *      full `certifications`. So if the user filters to "In Progress" and
+ *      none of those are marked featured, the grid renders all regular
+ *      cards — no awkward empty hero slot.
+ *
+ * ============================================================================
+ */

--- a/src/pages/CertificationsPage.tsx
+++ b/src/pages/CertificationsPage.tsx
@@ -9,6 +9,7 @@ const STATUS_FILTERS: { label: string; value: CertificationStatus | null }[] = [
   { label: 'All',         value: null },
   { label: 'Earned',      value: 'EARNED' },
   { label: 'In Progress', value: 'IN_PROGRESS' },
+  { label: 'Expired',     value: 'EXPIRED' },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- New `/certifications` page: hero header, status filter pills (All / Earned / In Progress), responsive grid
- `CertificationCard` gains a `featured` variant — 2-col hero card with primary-tinted border, outer glow, and decorative watermark
- Single fetch to `GET /certifications/published` on mount; filtering and featured selection happen client-side so tab switches are instant
- Sort: featured first, then displayOrder asc, then issueDate desc

Closes #10.

## Test plan
- [ ] Page loads published certifications from the backend
- [ ] All / Earned / In Progress filters show the expected subsets
- [ ] The first featured cert in the current view spans 2 columns with the glow treatment
- [ ] Empty state shows when a filter matches nothing
- [ ] Loading and error (with retry) states render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)