### PR TITLE
feat(resume): wire download buttons to backend (issue #12)

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { NavLink, Link } from 'react-router-dom';
+import { useResume } from '@/hooks';
 
 const navLinks = [
   { label: 'Home', to: '/' },
@@ -11,6 +12,7 @@ const navLinks = [
 
 export function Navbar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const resume = useResume();
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-surface-container-low/70 backdrop-blur-[16px] border-b border-outline-variant/15">
@@ -40,12 +42,16 @@ export function Navbar() {
         </div>
 
         <div className="flex items-center gap-4">
-          <a
-            href="#"
-            className="hidden rounded-md bg-gradient-to-br from-primary to-primary-dim px-5 py-2 font-headline text-sm font-bold tracking-wide text-on-primary shadow-[0_0_15px_rgba(163,166,255,0.3)] transition-transform hover:brightness-110 active:scale-95 sm:inline-block"
-          >
-            Resume
-          </a>
+          {resume.available && (
+            <a
+              href={resume.downloadUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hidden rounded-md bg-gradient-to-br from-primary to-primary-dim px-5 py-2 font-headline text-sm font-bold tracking-wide text-on-primary shadow-[0_0_15px_rgba(163,166,255,0.3)] transition-transform hover:brightness-110 active:scale-95 sm:inline-block"
+            >
+              Resume
+            </a>
+          )}
 
           {/* Mobile hamburger button */}
           <button
@@ -92,12 +98,17 @@ export function Navbar() {
                 {link.label}
               </NavLink>
             ))}
-            <a
-              href="#"
-              className="mt-2 rounded-md bg-gradient-to-br from-primary to-primary-dim px-4 py-3 text-center font-headline text-sm font-bold tracking-wide text-on-primary sm:hidden"
-            >
-              Resume
-            </a>
+            {resume.available && (
+              <a
+                href={resume.downloadUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setMobileMenuOpen(false)}
+                className="mt-2 rounded-md bg-gradient-to-br from-primary to-primary-dim px-4 py-3 text-center font-headline text-sm font-bold tracking-wide text-on-primary sm:hidden"
+              >
+                Resume
+              </a>
+            )}
           </div>
         </div>
       )}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,4 @@
 export { useScrollToTop } from './useScrollToTop';
 export { usePageTitle } from './usePageTitle';
+export { useResume } from './useResume';
+export type { UseResumeResult } from './useResume';

--- a/src/hooks/useResume.ts
+++ b/src/hooks/useResume.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { resumeApi } from '@/api/resume';
+import type { ResumeResponse } from '@/types';
+
+// ----------------------------------------------------------------------------
+// Module-level cache
+// ----------------------------------------------------------------------------
+
+// Shared promise across all hook consumers. The first mount kicks off the
+// request; any later mounts await the same promise instead of firing their
+// own. A 404 (no resume uploaded) resolves to `null` rather than rejecting —
+// so the caller can treat "no resume" as a legitimate state.
+let cachedPromise: Promise<ResumeResponse | null> | null = null;
+
+function fetchResumeOnce(): Promise<ResumeResponse | null> {
+  if (!cachedPromise) {
+    cachedPromise = resumeApi.getMetadata().catch(() => null);
+  }
+  return cachedPromise;
+}
+
+// ----------------------------------------------------------------------------
+// Hook
+// ----------------------------------------------------------------------------
+
+export interface UseResumeResult {
+  /** True once metadata resolves and a resume is available. */
+  available: boolean;
+  /** Backend URL that 302-redirects to the Cloudinary file. */
+  downloadUrl: string;
+  /** File name from metadata (e.g. "casey-quinn-resume.pdf"), or null. */
+  fileName: string | null;
+  /** True while the initial metadata fetch is in flight. */
+  loading: boolean;
+}
+
+/**
+ * Reads resume metadata and exposes a render-ready download URL.
+ *
+ * Intended for the "Download Resume" buttons in the navbar and on the
+ * homepage. Consumers typically render the button only when `available`
+ * is true, so a portfolio without an uploaded resume just hides the CTA
+ * instead of linking to a broken page.
+ *
+ * The underlying fetch is shared across all mounts via a module-level
+ * cache — no duplicate network calls when multiple components use the hook.
+ */
+export function useResume(): UseResumeResult {
+  const [metadata, setMetadata] = useState<ResumeResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetchResumeOnce().then((data) => {
+      if (cancelled) return;
+      setMetadata(data);
+      setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return {
+    available: metadata !== null,
+    downloadUrl: resumeApi.getDownloadUrl(),
+    fileName: metadata?.fileName ?? null,
+    loading,
+  };
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { usePageTitle } from '@/hooks';
+import { usePageTitle, useResume } from '@/hooks';
 import { projectApi } from '@/api/projects';
 import { technologyApi } from '@/api/technologies';
 import { SectionHeader, ProjectCard, TechnologyShowcase, LoadingSpinner, ErrorDisplay, Button } from '@/components/ui';
@@ -9,6 +9,7 @@ import heroImage from '@/assets/hero.png';
 
 export function HomePage() {
   usePageTitle('');
+  const resume = useResume();
 
   // ---- State for featured projects ----
   const [projects, setProjects] = useState<ProjectResponse[]>([]);
@@ -74,14 +75,22 @@ export function HomePage() {
           </p>
           <div className="flex flex-wrap gap-4 pt-4">
             <Button href="/projects" size="lg">View Projects</Button>
-            <Button variant="secondary" href="#" size="lg">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <polyline points="7 10 12 15 17 10" />
-                <line x1="12" y1="15" x2="12" y2="3" />
-              </svg>
-              Download Resume
-            </Button>
+            {resume.available && (
+              <Button
+                variant="secondary"
+                href={resume.downloadUrl}
+                size="lg"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <polyline points="7 10 12 15 17 10" />
+                  <line x1="12" y1="15" x2="12" y2="3" />
+                </svg>
+                Download Resume
+              </Button>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- New `useResume` hook fetches `/resume` metadata via a module-level promise cache — Navbar and HomePage share one request per app session
- 404 (no resume uploaded) resolves to `null`, so callers just check `available` to decide whether to render
- Navbar Resume button (desktop + mobile) + HomePage hero "Download Resume" button now link to the real backend download URL with `target=_blank` + `rel=noopener noreferrer`
- When no resume is uploaded, both CTAs render `null` — no broken link, no awkward placeholder

Closes #12.

## Test plan
- [x] Click Resume in the navbar → downloads the current PDF with the correct filename and extension
- [x] Click Download Resume in the homepage hero → same behavior
- [ ] Remove the resume via admin → CTAs disappear after a reload
- [ ] Mobile menu: tap Resume closes the menu and triggers download

🤖 Generated with [Claude Code](https://claude.com/claude-code)