### PR TITLE
feat(projects): render fullDescription as markdown on project detail

### DIFF
--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -3,6 +3,11 @@ import { useParams, Link } from 'react-router-dom';
 import { useMeta } from '@/hooks';
 import { projectApi } from '@/api/projects';
 import { TechPill, StatusBadge, ProjectLinks, ProjectGallery, LoadingSpinner, ErrorDisplay } from '@/components/ui';
+// Direct file import (bypasses the barrel) so the heavy markdown +
+// syntax-highlighter libs only land in the chunks for routes that need
+// them. Vite hoists the libs into a shared chunk because BlogPostPage
+// also imports MarkdownRenderer this way.
+import { MarkdownRenderer } from '@/components/ui/MarkdownRenderer';
 import { formatDate } from '@/utils';
 import type { ProjectResponse, ProjectImageResponse } from '@/types';
 
@@ -230,11 +235,7 @@ export function ProjectDetailPage() {
               <h2 className="text-2xl font-bold text-on-surface border-l-2 border-primary pl-6 font-headline">
                 Mission Overview
               </h2>
-              <div className="font-body text-lg leading-relaxed text-on-surface-variant space-y-6">
-                {project.fullDescription.split('\n\n').map((paragraph: string, i: number) => (
-                  <p key={i}>{paragraph}</p>
-                ))}
-              </div>
+              <MarkdownRenderer content={project.fullDescription} />
             </div>
           )}
 


### PR DESCRIPTION
## Summary

Drops the naive paragraph-split rendering on `ProjectDetailPage` in favor of `MarkdownRenderer`, so AI-generated and longform project writeups display with proper headings, lists, code blocks, and emphasis. Plain-text content remains valid markdown and renders unchanged, so existing projects without markdown syntax aren't affected.

Mirrors the import pattern used by `BlogPostPage`: direct file import from `@/components/ui/MarkdownRenderer` (bypasses the components/ui barrel) so the heavy `react-markdown` + `react-syntax-highlighter` deps stay isolated to chunks that need them.

## Bundle impact

Vite now hoists the markdown libs into a shared chunk referenced by both `BlogPostPage` and `ProjectDetailPage`:

| | Before | After |
|---|---|---|
| BlogPostPage chunk | 790 kB (libs bundled in) | 6 kB + shared 784 kB |
| ProjectDetailPage chunk | 7 kB | 7 kB + shared 784 kB |

Total app weight is unchanged. Cross-page navigation benefits because the shared chunk is downloaded once and cached.

## Test plan

- [x] `npm run build` succeeds with shared chunking as expected
- [ ] After deploy: visit a project detail page with markdown content (the visa-related project) and confirm headings, lists, code, emphasis all render
- [ ] After deploy: visit a project detail page with plain-text content and confirm it still renders cleanly (markdown treats it as a single paragraph)
- [ ] After deploy: visit a blog post and confirm BlogPostPage still works (regression check on the shared chunk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)