### PR TITLE
refactor(projects): rename links section to Resources

### DIFF
--- a/src/components/ui/ProjectLinks.tsx
+++ b/src/components/ui/ProjectLinks.tsx
@@ -106,7 +106,7 @@ export function ProjectLinks({ links }: ProjectLinksProps) {
   return (
     <div className="space-y-6">
       <h2 className="text-xl font-bold text-on-surface font-headline">
-        Repository & Deployment
+        Resources
       </h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {links.map((link: ProjectLinkResponse, index: number) => {


### PR DESCRIPTION
## Summary

Renames the project detail page's links section heading from "Repository & Deployment" to "Resources" so it reads sensibly for non-code projects (articles, press, references) without losing meaning for code projects.

One-line change in `src/components/ui/ProjectLinks.tsx`.

## Test plan

- [ ] After deploy: visit a software project's detail page and confirm the heading reads "Resources" without breaking the existing layout
- [ ] After deploy: visit a non-software project's detail page and confirm the heading is no longer misleading

🤖 Generated with [Claude Code](https://claude.com/claude-code)