### PR TITLE
feat(projects): support displayInGallery flag to avoid inline-image duplication

### DIFF
--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -117,7 +117,14 @@ export function ProjectDetailPage() {
   // ---- Derived data ----
   const images: ProjectImageResponse[] = project.images ?? [];
   const primaryImage: ProjectImageResponse | undefined = images.find((img) => img.isPrimary) ?? images[0];
-  const galleryImages: ProjectImageResponse[] = images.filter((img) => img !== primaryImage);
+  // Exclude the primary image (already shown as the hero) and any image
+  // explicitly flagged `displayInGallery: false` — those are inlined in
+  // the markdown content via `![alt](url)` and shouldn't double up in the
+  // gallery. `!== false` (rather than truthy) so legacy responses without
+  // the field still render in the gallery.
+  const galleryImages: ProjectImageResponse[] = images.filter(
+    (img) => img !== primaryImage && img.displayInGallery !== false,
+  );
   const technologies = project.technologies ?? [];
   const links = project.links ?? [];
 

--- a/src/types/responses.ts
+++ b/src/types/responses.ts
@@ -62,6 +62,9 @@ export interface ProjectImageResponse {
   imageType: ImageType;
   displayOrder: number;
   isPrimary: boolean;
+  // Optional because legacy/cached responses may not include it.
+  // Treat missing/undefined as `true` (image shown in gallery).
+  displayInGallery?: boolean;
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary

The backend now returns a `displayInGallery` boolean on `ProjectImageResponse`. When `false`, the image is meant to be embedded inline in the project's markdown `fullDescription` via `![alt](url)` and should not also appear in the gallery section, which would duplicate it.

## Changes

- **`src/types/responses.ts`** — add optional `displayInGallery?: boolean` to `ProjectImageResponse`. Optional because cached/legacy responses may not include it.
- **`src/pages/ProjectDetailPage.tsx`** — gallery filter now also excludes images where `displayInGallery === false`. Uses `!== false` (rather than truthy check) so missing/undefined treats the image as visible — preserves legacy behavior.
- **Hero/primary image selection is unchanged** — `images.find((img) => img.isPrimary)` operates on the full unfiltered list. Per the spec: hero selection is independent of the gallery filter.
- **Markdown renderer** already supports `<img>` via the `components` map (line 72). No change needed for inline images to work.

## Test plan

- [x] `npm run build` passes; types are clean.
- [ ] After deploy: visit the VARM Batch File project — architecture diagram appears once, inline in the `## Architecture` section. The gallery below should NOT show it.
- [ ] After deploy: visit any other project whose images have `displayInGallery: true` (or undefined) — gallery still renders them as before.
- [ ] After deploy: hero image selection on home page cards is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)