### PR TITLE
fix(projects): hero fallback skips displayInGallery=false images

### DIFF
--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -116,7 +116,13 @@ export function ProjectDetailPage() {
 
   // ---- Derived data ----
   const images: ProjectImageResponse[] = project.images ?? [];
-  const primaryImage: ProjectImageResponse | undefined = images.find((img) => img.isPrimary) ?? images[0];
+  // Prefer an explicit isPrimary image. Otherwise fall back to the first
+  // gallery-eligible image — never an image flagged `displayInGallery: false`,
+  // since those are meant for inline use in the markdown content only and
+  // promoting one to hero would surface it in two places.
+  const primaryImage: ProjectImageResponse | undefined =
+    images.find((img) => img.isPrimary) ??
+    images.find((img) => img.displayInGallery !== false);
   // Exclude the primary image (already shown as the hero) and any image
   // explicitly flagged `displayInGallery: false` — those are inlined in
   // the markdown content via `![alt](url)` and shouldn't double up in the


### PR DESCRIPTION
## Summary

The hero/primary image selection on `ProjectDetailPage` had a fallback to `images[0]` when no image was flagged `isPrimary: true`. With the new `displayInGallery: false` flag, that fallback could promote an inline-only image (like an architecture diagram) to the hero slot — surfacing it twice on the page (hero + inlined in markdown).

Reproducer: VARM Email Ingestion Pipeline — only one image, an architecture diagram with `isPrimary: false` and `displayInGallery: false`. The diagram was being picked as the hero by the `?? images[0]` fallback.

## Fix

Hero fallback now picks the first **gallery-eligible** image (`displayInGallery !== false`) instead of `images[0]` blindly. Projects with no eligible image and no `isPrimary` render no hero — which is correct given the author's stated intent.

`isPrimary: true` still wins regardless of `displayInGallery`, so authors retain full control if they want a normally-inline-only image to also serve as hero.

## Test plan

- [ ] After deploy: VARM Email Ingestion project page renders no hero (only the inline diagram in markdown).
- [ ] Other projects with `isPrimary: true` set explicitly continue to show the same hero.
- [ ] Projects with no `isPrimary` and a normal first image (no `displayInGallery: false`) still get that image as hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)