### PR TITLE
fix(projects): card thumbnail skips displayInGallery=false images

### DIFF
--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -9,7 +9,13 @@ interface ProjectCardProps {
 
 export function ProjectCard({ project }: ProjectCardProps) {
   const images = project.images ?? [];
-  const primaryImage = images.find((img) => img.isPrimary) ?? images[0];
+  // Mirror ProjectDetailPage's hero selection: prefer an explicit
+  // isPrimary image, otherwise fall back to the first gallery-eligible
+  // one. Never promote an image flagged `displayInGallery: false` —
+  // those are meant for inline use in the project's markdown content.
+  const primaryImage =
+    images.find((img) => img.isPrimary) ??
+    images.find((img) => img.displayInGallery !== false);
 
   return (
     <article className="group bg-surface-container-low p-8 rounded-xl transition-all duration-300 hover:bg-surface-container-highest hover:shadow-[0_1px_0_0_rgba(163,166,255,0.4)_inset] relative overflow-hidden">


### PR DESCRIPTION
## Summary

Same bug pattern as PR #27, second location. `ProjectCard.tsx` had the identical `?? images[0]` fallback for thumbnail selection, so projects with no `isPrimary` image and only inline-only images (architecture diagrams, etc.) were showing those diagrams as thumbnails on the home page Featured Projects grid and the `/projects` listing.

Reproducer: VARM Email Ingestion Pipeline. Detail page hero was fixed by PR #27, but the home page thumbnail still showed the diagram.

## Fix

Mirror the ProjectDetailPage logic — prefer `isPrimary`, otherwise fall back to the first **gallery-eligible** image (`displayInGallery !== false`). `ProjectCard` is shared by `HomePage` and `ProjectsPage`, so one change fixes both.

## Test plan

- [ ] After deploy: home page Featured Projects grid no longer shows the architecture diagram for VARM Email Ingestion.
- [ ] After deploy: `/projects` listing also no longer shows it.
- [ ] After deploy: every project that does have an `isPrimary` image keeps showing the same thumbnail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)