### PR TITLE
content(home): update employment status and add personal-site disclaimer

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -16,6 +16,9 @@ export function Footer() {
           <div className="mt-1 text-sm text-on-surface-variant/60">
             &copy; {new Date().getFullYear()} Casey Quinn. Crafted with precision.
           </div>
+          <div className="mt-1 text-xs text-on-surface-variant/40">
+            Personal site. Views and projects shown are my own and do not represent any employer.
+          </div>
         </div>
 
         <div className="flex items-center gap-8">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -63,7 +63,7 @@ export function HomePage() {
         <div className="md:col-span-7 space-y-8 md:ml-[10%]">
           <div className="space-y-4">
             <h2 className="text-primary font-headline font-medium tracking-widest text-sm uppercase">
-              Available for work
+              Senior Associate Software Engineer @ JPMorganChase
             </h2>
             <h1 className="text-6xl md:text-7xl font-headline font-bold text-on-surface tracking-tighter leading-[0.9]">
               Casey Quinn
@@ -175,7 +175,7 @@ export function HomePage() {
             Ready to build the next generation?
           </h2>
           <p className="text-on-surface-variant text-xl">
-            Let's talk about your system architecture and how I can help bring precision to your code.
+            Always up for a conversation about distributed systems, engineering craft, or anything you've been building.
           </p>
           <div className="pt-8">
             <Link


### PR DESCRIPTION
## Summary

Updates home-page copy to reflect current employment and adds a footer disclaimer.

- Hero eyebrow: \"Available for work\" → \"Senior Associate Software Engineer @ JPMorganChase\"
- CTA subhead: pivot from freelancer pitch (\"how I can help bring precision to your code\") to peer-networking framing so the page doesn't imply availability for new roles
- Footer: one-line disclaimer that the site is personal and views/projects shown don't represent any employer — standard practice for engineers in financial services

Hero headline (\"Ready to build the next generation?\") left intact — reads aspirational, not as a solicitation.

## Test plan

- [ ] After deploy: home hero eyebrow shows the new title; resume + view-projects buttons unchanged
- [ ] After deploy: CTA section reads as networking, not solicitation
- [ ] After deploy: footer shows the personal-site disclaimer beneath the copyright on every page

🤖 Generated with [Claude Code](https://claude.com/claude-code)