### PR TITLE
style(home): abbreviate role line to fit on mobile

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -67,7 +67,7 @@ export function HomePage() {
             </h1>
             <div className="space-y-3">
               <p className="text-2xl text-secondary-dim font-headline font-light tracking-tight">
-                Senior Associate Software Engineer
+                Senior Associate SWE
               </p>
               <p className="text-xs md:text-sm text-primary font-headline font-semibold tracking-[0.25em] uppercase">
                 @ JPMorganChase


### PR DESCRIPTION
## Summary

"Senior Associate Software Engineer" wrapped onto two lines on narrow viewports, breaking the visual rhythm with the @ JPMORGANCHASE byline below. Abbreviates to "Senior Associate SWE" — industry-standard shorthand that reads naturally to this site's engineering audience while keeping the meaningful level descriptor ("Senior Associate") intact.

## Test plan

- [ ] After deploy: home hero role line fits on a single line on mobile (≤375 px) and desktop.
- [ ] Two-line structure (role / @ JPMORGANCHASE) reads cleanly without awkward wraps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)